### PR TITLE
Fix issue where pigeon is unable to fetch the right valset_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 tmp
 dist/
+build

--- a/app/app.go
+++ b/app/app.go
@@ -20,6 +20,11 @@ import (
 	"github.com/vizualni/whoops"
 )
 
+const (
+	AppName     = "pigeon"
+	AppNameCaps = "PIGEON"
+)
+
 var (
 	_relayer    *relayer.Relayer
 	_config     *config.Root

--- a/chain/evm/client_test.go
+++ b/chain/evm/client_test.go
@@ -242,11 +242,11 @@ func TestFilterLogs(t *testing.T) {
 					}).Times(1).Return(results[index], nil)
 				}
 
-				callResults(5, 8, 1)
-				callResults(0, 4, 0)
+				callResults(5, 8, 0)
+				callResults(0, 4, 1)
 				return srv
 			},
-			expRes: []types.Log{log4, log5, log1, log2, log3},
+			expRes: []types.Log{log5, log4, log3, log2, log1},
 		},
 		{
 			name:        "any other error is returned",
@@ -270,7 +270,7 @@ func TestFilterLogs(t *testing.T) {
 			var res []types.Log
 			defaultCallback := func(logs []types.Log) bool {
 				res = append(res, logs...)
-				return true
+				return false
 			}
 
 			var fnc func([]types.Log) bool

--- a/chain/evm/client_test.go
+++ b/chain/evm/client_test.go
@@ -226,8 +226,8 @@ func TestFilterLogs(t *testing.T) {
 			blockHeight: big.NewInt(8),
 			setup: func(t *testing.T) *mockEthClientToFilterLogs {
 				results := [][]types.Log{
-					{log1, log2, log3},
 					{log4, log5},
+					{log1, log2, log3},
 				}
 				srv := newMockEthClientToFilterLogs(t)
 
@@ -242,11 +242,11 @@ func TestFilterLogs(t *testing.T) {
 					}).Times(1).Return(results[index], nil)
 				}
 
-				callResults(0, 4, 0)
 				callResults(5, 8, 1)
+				callResults(0, 4, 0)
 				return srv
 			},
-			expRes: []types.Log{log1, log2, log3, log4, log5},
+			expRes: []types.Log{log4, log5, log1, log2, log3},
 		},
 		{
 			name:        "any other error is returned",
@@ -284,7 +284,7 @@ func TestFilterLogs(t *testing.T) {
 				fnc = defaultCallback
 			}
 
-			_, err := filterLogs(ctx, ethClienter, tt.filterQuery, tt.blockHeight, fnc)
+			_, err := filterLogs(ctx, ethClienter, tt.filterQuery, tt.blockHeight, true, fnc)
 
 			require.ErrorIs(t, err, tt.expErr)
 			require.Equal(t, tt.expRes, res)

--- a/chain/evm/errors.go
+++ b/chain/evm/errors.go
@@ -11,5 +11,12 @@ const (
 	ErrUnsupportedMessageType    = whoops.Errorf("unsupported message type: %T")
 	ErrABINotInitialized         = whoops.String("ABI is not initialized")
 
+	ErrEvm = whoops.String("EVM related error")
+
 	ErrNoConsensus = whoops.String("no consensus reached")
+)
+
+const (
+	FieldMessageID   whoops.Field[uint64] = "message id"
+	FieldMessageType whoops.Field[any]    = "message type"
 )

--- a/cmd/pigeon/main.go
+++ b/cmd/pigeon/main.go
@@ -4,11 +4,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/palomachain/pigeon/app"
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	logLevelEnvName = "LOG_LEVEL"
+	logLevelEnvName = app.AppNameCaps + "_LOG_LEVEL"
 )
 
 func main() {
@@ -16,7 +17,10 @@ func main() {
 	if err == nil {
 		logrus.SetLevel(level)
 	}
-	logrus.SetReportCaller(true)
+
+	if level == logrus.DebugLevel || level == logrus.TraceLevel {
+		logrus.SetReportCaller(true)
+	}
 
 	if err := rootCmd.Execute(); err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/strangelove-ventures/lens v0.3.1-0.20220329150126-16b15e90cf34
 	github.com/stretchr/testify v1.7.1
 	github.com/tendermint/tendermint v0.34.15
-	github.com/vizualni/whoops v0.6.0
+	github.com/vizualni/whoops v0.7.1
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac
 	google.golang.org/grpc v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -1077,8 +1077,8 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vizualni/whoops v0.6.0 h1:jHN4PGJUDshkvl/zgCe+H045o15/2E4P0TGQ+2iKSgI=
-github.com/vizualni/whoops v0.6.0/go.mod h1:V5mMF1aBNKTtOpQvlka6V/5F6AaUlCOw3exsBFYPX/M=
+github.com/vizualni/whoops v0.7.1 h1:1HUk7HZOQstyx50cEEQ08rZCqMmlNfpu1KdWZ2aMWJQ=
+github.com/vizualni/whoops v0.7.1/go.mod h1:V5mMF1aBNKTtOpQvlka6V/5F6AaUlCOw3exsBFYPX/M=
 github.com/vmihailenco/msgpack/v5 v5.1.4/go.mod h1:C5gboKD0TJPqWDTVTtrQNfRbiBwHZGo8UTqP/9/XvLI=
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/volumefi/lens-1 v0.3.1-0.20220502123822-4cb1add1e482 h1:8RYuDx9ovDLc3qpueA7D+WFWoTNps/nT40NijG2gH1Y=

--- a/relayer/process.go
+++ b/relayer/process.go
@@ -10,11 +10,10 @@ import (
 )
 
 func (r *Relayer) Process(ctx context.Context, processors []chain.Processor) error {
-	for chainID, p := range processors {
+	for _, p := range processors {
 		for _, queueName := range p.SupportedQueues() {
 			logger := log.WithFields(log.Fields{
-				"processor-chain-id": chainID,
-				"queue-name":         queueName,
+				"queue-name": queueName,
 			})
 
 			// TODO: remove comments once signing is done on the paloma side.

--- a/util/slice/reverse.go
+++ b/util/slice/reverse.go
@@ -1,0 +1,7 @@
+package slice
+
+func ReverseInplace[V any](slice []V) {
+	for i, j := 0, len(slice)-1; i < j; i, j = i+1, j-1 {
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/341
- https://github.com/palomachain/paloma/issues/338

# Background

There was a bug where pigeon was querying the valset by the provided starting height of a supported chain, while valset can only be added **after** the fact that we have added a support for a new chain.

# Testing completed

- [x] ensured that existing tests work
