### PR TITLE
update chain-id to paloma-testnet-7 for new chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Create configuration file here `~/.pigeon/config.yaml`
 loop-timeout: 5s
 
 paloma:
-  chain-id: paloma-testnet-6
+  chain-id: paloma-testnet-7
   call-timeout: 20s
   keyring-dir: ~/.paloma
   keyring-pass-env-name: PALOMA_KEYRING_PASS


### PR DESCRIPTION
# Related Github tickets

New chain to address upgrade to fix validator jailing issue around pigeon balances.

# Background
Update the README with the new chain id, paloma-testnet-7

# Testing completed
None as yet. Will verify with new network.