### PR TITLE
Update keyring-type to os

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ paloma:
   call-timeout: 20s
   keyring-dir: ~/.paloma
   keyring-pass-env-name: PALOMA_KEYRING_PASS
-  keyring-type: test
+  keyring-type: os
   signing-key: ${VALIDATOR}
   base-rpc-url: http://localhost:26657
   gas-adjustment: 1.5


### PR DESCRIPTION
# Related Github tickets
N/A

# Background
pigeon config.yaml still references `keyring-type: test` updating to `keyring-type: os`

# Testing completed
Currently live.
