### PR TITLE
Add healtchecks which do not depend on the paloma running

### DIFF
--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -142,7 +142,7 @@ func (c *Client) init() error {
 		}
 		acc := accounts.Account{Address: c.addr}
 
-		c.keystore.Unlock(acc, config.KeyringPassword(c.config.KeyringPassEnvName))
+		whoops.Assert(c.keystore.Unlock(acc, config.KeyringPassword(c.config.KeyringPassEnvName)))
 
 		c.conn = whoops.Must(ethclient.Dial(c.config.BaseRPCURL))
 	})

--- a/chain/evm/health_check.go
+++ b/chain/evm/health_check.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/palomachain/pigeon/chain"
+	"github.com/palomachain/pigeon/config"
 )
 
 func (p Processor) HealthCheck(ctx context.Context) error {
@@ -25,5 +26,20 @@ func (p Processor) HealthCheck(ctx context.Context) error {
 		return chain.ErrAccountBalanceLow.Format(balance, p.evmClient.addr, p.chainReferenceID, p.minOnChainBalance)
 	}
 
+	return nil
+}
+
+func TestAndVerifyConfig(ctx context.Context, cfg config.EVM) error {
+	cli := &Client{
+		config: cfg,
+	}
+	err := cli.init()
+	if err != nil {
+		return err
+	}
+	_, err = cli.conn.BlockNumber(ctx)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/cmd/pigeon/cmd_health_check_verify.go
+++ b/cmd/pigeon/cmd_health_check_verify.go
@@ -10,6 +10,7 @@ var (
 		Use:   "health-check",
 		Short: "Verifies the health of pigeon.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app.HealthCheckService().BootChecker(cmd.Context())
 			app.HealthCheckService().Check(cmd.Context())
 			return nil
 		},

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -21,9 +21,3 @@ evm:
     signing-key: 0xe4Ab6f4D62Ba7e0bBC4CF6c5E8153e105108FBa9
     keyring-dir: ~/.pigeon/keys/evm/ropsten
     gas-adjustment: 2.0
-  bla:
-    base-rpc-url: https://ropsten.infura.io/v3/d697ced03e7c49209a1fe2a1c8858821
-    keyring-pass-env-name: ROPSTEN_PASS
-    signing-key: 0xe4Ab6f4D62Ba7e0bBC4CF6c5E8153e105108FBa9
-    keyring-dir: ~/.sparrow/keys/evm/ropsten
-    gas-adjustment: 2.0

--- a/health/background_check.go
+++ b/health/background_check.go
@@ -56,3 +56,21 @@ func (s Service) Check(ctx context.Context) {
 		log.Fatal("exiting due to health check failures")
 	}
 }
+
+func (s Service) BootChecker(ctx context.Context) {
+	var g whoops.Group
+
+	for _, hc := range s.Checks {
+		b, ok := hc.(BootChecker)
+		if !ok {
+			continue
+		}
+		g.Add(b.BootHealthCheck(ctx))
+	}
+
+	if g.Err() {
+		for _, err := range g {
+			log.WithError(err).Warn("boot health check failed")
+		}
+	}
+}

--- a/health/interface.go
+++ b/health/interface.go
@@ -5,3 +5,7 @@ import "context"
 type Checker interface {
 	HealthCheck(ctx context.Context) error
 }
+
+type BootChecker interface {
+	BootHealthCheck(ctx context.Context) error
+}

--- a/relayer/health_check.go
+++ b/relayer/health_check.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/palomachain/pigeon/chain/evm"
 	log "github.com/sirupsen/logrus"
 	"github.com/vizualni/whoops"
 
@@ -73,5 +74,13 @@ func (r *Relayer) HealthCheck(ctx context.Context) error {
 		return nil
 	}
 
+	return g.Return()
+}
+
+func (r *Relayer) BootHealthCheck(ctx context.Context) error {
+	var g whoops.Group
+	for _, cfg := range r.config.EVM {
+		g.Add(evm.TestAndVerifyConfig(ctx, cfg))
+	}
 	return g.Return()
 }

--- a/relayer/process.go
+++ b/relayer/process.go
@@ -61,8 +61,7 @@ func (r *Relayer) Process(ctx context.Context, processors []chain.Processor) err
 				loggerQueuedMessages = loggerQueuedMessages.WithFields(log.Fields{
 					"signed-messages": slice.Map(signedMessages, func(msg chain.SignedQueuedMessage) log.Fields {
 						return log.Fields{
-							"id":        msg.ID,
-							"signature": msg.Signature,
+							"id": msg.ID,
 						}
 					}),
 				})


### PR DESCRIPTION
# Background

Check if new chains are properly configured.

# Testing completed

- [x] manually tested
- [x] didn't wrote tests as I am tired and it's late, but this is not touching any existing business logic
