### PR TITLE
fix fetch event bug

### DIFF
--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -521,3 +521,11 @@ func (c Client) FindBlockNearestToTime(ctx context.Context, startingHeight uint6
 
 	return res, nil
 }
+
+func (c Client) FindCurrentBlockNumber(ctx context.Context) (*big.Int, error) {
+	header, err := c.conn.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return big.NewInt(0), err
+	}
+	return header.Number, nil
+}

--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -525,7 +525,7 @@ func (c Client) FindBlockNearestToTime(ctx context.Context, startingHeight uint6
 func (c Client) FindCurrentBlockNumber(ctx context.Context) (*big.Int, error) {
 	header, err := c.conn.HeaderByNumber(ctx, nil)
 	if err != nil {
-		return big.NewInt(0), err
+		return nil, err
 	}
 	return header.Number, nil
 }

--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -381,7 +381,7 @@ func (t compass) isArbitraryCallAlreadyExecuted(ctx context.Context, messageID u
 	var found bool
 	_, err = t.evm.FilterLogs(ctx, filter, nil, func(logs []etherumtypes.Log) bool {
 		found = len(logs) > 0
-		return !found
+		return found
 	})
 
 	if err != nil {

--- a/chain/evm/mock_evmClienter_test.go
+++ b/chain/evm/mock_evmClienter_test.go
@@ -175,6 +175,32 @@ func (_m *mockEvmClienter) TransactionByHash(ctx context.Context, txHash common.
 	return r0, r1, r2
 }
 
+// FindCurrentBlockNumber provides a mock function with given fields: ctx
+func (_m *mockEvmClienter) FindCurrentBlockNumber(ctx context.Context) (*big.Int, error) {
+	ret := _m.Called(ctx)
+
+	var r0 *big.Int
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*big.Int, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *big.Int); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type mockConstructorTestingTnewMockEvmClienter interface {
 	mock.TestingT
 	Cleanup(func())


### PR DESCRIPTION
# Related Github tickets

https://github.com/VolumeFi/paloma/issues/8

# Background

- fix wrong function name.
- fix weird boolean returns.
- call `isArbitraryCallAlreadyExecuted()` function only once with maximum fetch block length(9999).