### PR TITLE
removed amd64-v3 demand from goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,6 @@ builds:
       - darwin
     goarch:
       - amd64
-    goamd64:
-      - v3
-
 
 archives:
   - replacements:


### PR DESCRIPTION
# Related Github tickets

n/a

# Background

On the machine from 2019-2020 the Pigeon binary can not be launched, however Paloma can.
