### PR TITLE
Moving sleep to before sending a message

### DIFF
--- a/chain/paloma/wrappers.go
+++ b/chain/paloma/wrappers.go
@@ -42,9 +42,9 @@ func (g GRPCClientDowner) NewStream(ctx context.Context, desc *ggrpc.StreamDesc,
 }
 
 func (m MessageSenderDowner) SendMsg(ctx context.Context, msg sdk.Msg, memo string) (*sdk.TxResponse, error) {
+	time.Sleep(10 * time.Second)
 	log.Debug("Sending Msg: ", msg)
 	res, err := m.W.SendMsg(ctx, msg, memo)
-	time.Sleep(10 * time.Second)
 
 	if IsPalomaDown(err) {
 		return nil, whoops.Wrap(ErrPalomaIsDown, err)


### PR DESCRIPTION
# Background

It occurred to me that if we had a message come in 9 seconds after the previous, we wouldn't get the desired 10 second spread between messages. Moving the sleep fixes this
