### PR TITLE
Toaster/fix glibc errors

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,8 @@ builds:
       - linux
     goarch:
       - amd64
+    env:
+      - CGO_ENABLED=0
 
 archives:
   - replacements:

--- a/chain/paloma/wrappers.go
+++ b/chain/paloma/wrappers.go
@@ -42,9 +42,9 @@ func (g GRPCClientDowner) NewStream(ctx context.Context, desc *ggrpc.StreamDesc,
 }
 
 func (m MessageSenderDowner) SendMsg(ctx context.Context, msg sdk.Msg, memo string) (*sdk.TxResponse, error) {
+	time.Sleep(10 * time.Second)
 	log.Debug("Sending Msg: ", msg)
 	res, err := m.W.SendMsg(ctx, msg, memo)
-	time.Sleep(10 * time.Second)
 
 	if IsPalomaDown(err) {
 		return nil, whoops.Wrap(ErrPalomaIsDown, err)


### PR DESCRIPTION
# Background

The crux of this issue is that the version of glibc on the github machine that builds this vs that of those who run it may be different. We need to use this env variables build in the libraries instead of dynamically loading them on the host machine at runtime.

# Testing completed

- [x] I built paloma and deployed it to a server that experienced these errors previously.  The errors no longer occur.

# Breaking changes

- [x] I have checked my code for breaking changes
