### PR TITLE
Fix GLIBC errors seen by some

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,8 @@ builds:
       - linux
     goarch:
       - amd64
+    env:
+      - CGO_ENABLED=0
 
 archives:
   - replacements:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [v1.0.0]
+* (118cf7b) Fix GLIBC errors seen by some (#157)
 * (b7ce8f2) Fixing locking issue (#153)
 * (3f26dc5) Moving sleep to before sending a message  (#148)
 * (34e1a87) Slow down Pigeon messages  (#145)


### PR DESCRIPTION
# Background

The crux of this issue is that the version of glibc on the github machine that builds this vs that of those who run it may be different. We need to use this env variables build in the libraries instead of dynamically loading them on the host machine at runtime.

# Testing completed

- [x] I built paloma and deployed it to a server that experienced these errors previously.  The errors no longer occur.

# Breaking changes

- [x] I have checked my code for breaking changes