### PR TITLE
Revert "Fix GLIBC errors seen by some"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,8 +15,6 @@ builds:
       - linux
     goarch:
       - amd64
-    env:
-      - CGO_ENABLED=0
 
 archives:
   - replacements:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## [v1.0.0]
-* (118cf7b) Fix GLIBC errors seen by some (#157)
 * (b7ce8f2) Fixing locking issue (#153)
 * (3f26dc5) Moving sleep to before sending a message  (#148)
 * (34e1a87) Slow down Pigeon messages  (#145)


### PR DESCRIPTION
Reverts palomachain/pigeon#159

This is failing to build.  In order to fix the build issue, we're going to have the change the lens dependency we're using.  That's too much change for a patch into a release already being voted on.  Reverting to removing this change from the release of Pigeon.

If teams hit the GLIBC error, the fix will be to pull the code and build it themselves for this version.