### PR TITLE
Revert building with CGO disabled

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,8 +15,6 @@ builds:
       - linux
     goarch:
       - amd64
-    env:
-      - CGO_ENABLED=0
 
 archives:
   - replacements:


### PR DESCRIPTION
# Background

This was done to try and get around glibc errors related to building on one machine and running on another.  This caused unexpected errors elswhere and needs reverted to keep the master branch buildable.
