### PR TITLE
Fix and refactor some process logic

### DIFF
--- a/relayer/process.go
+++ b/relayer/process.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/VolumeFi/whoops"
 	"github.com/palomachain/pigeon/chain"
 	"github.com/palomachain/pigeon/chain/paloma"
 	"github.com/palomachain/pigeon/chain/paloma/collision"
@@ -11,16 +12,115 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *Relayer) Process(ctx context.Context, processors []chain.Processor) error {
-	if len(processors) == 0 {
-		return nil
+func (r *Relayer) SignMessages(ctx context.Context, queueName string, messagesForSigning []chain.QueuedMessage, processor chain.Processor) error {
+	loggerQueuedMessages := log.WithFields(log.Fields{
+		"queue-name": queueName,
+		"message-ids": slice.Map(messagesForSigning, func(msg chain.QueuedMessage) uint64 {
+			return msg.ID
+		}),
+	})
+
+	if len(messagesForSigning) > 0 {
+		loggerQueuedMessages.Info("messages to sign")
+		signedMessages, err := processor.SignMessages(ctx, queueName, messagesForSigning...)
+		if err != nil {
+			loggerQueuedMessages.WithError(err).Error("unable to sign messages")
+			return err
+		}
+		loggerQueuedMessages = loggerQueuedMessages.WithFields(log.Fields{
+			"signed-messages": slice.Map(signedMessages, func(msg chain.SignedQueuedMessage) log.Fields {
+				return log.Fields{
+					"id": msg.ID,
+				}
+			}),
+		})
+		loggerQueuedMessages.Info("signed messages")
+
+		if err = r.broadcastSignatures(ctx, queueName, signedMessages); err != nil {
+			loggerQueuedMessages.WithError(err).Error("couldn't broadcast signatures and process attestation")
+			return err
+		}
 	}
+	return nil
+}
+
+func (r *Relayer) RelayMessages(ctx context.Context, queueName string, messagesInQueue []chain.MessageWithSignatures, p chain.Processor) error {
+	logger := log.WithFields(log.Fields{
+		"queue-name": queueName,
+	})
 
 	ctx, cleanup, err := collision.GoStartLane(ctx, r.palomaClient, r.palomaClient.GetValidatorAddress())
 	if err != nil {
 		return err
 	}
 	defer cleanup()
+
+	relayCandidateMsgs := slice.Filter(
+		messagesInQueue,
+		func(msg chain.MessageWithSignatures) bool {
+			return len(msg.PublicAccessData) == 0
+		},
+		func(msg chain.MessageWithSignatures) bool {
+			return collision.AllowedToExecute(
+				ctx,
+				[]byte(fmt.Sprintf("%s-%d", queueName, msg.ID)),
+			)
+		},
+	)
+
+	if len(relayCandidateMsgs) > 0 {
+		logger := logger.WithFields(log.Fields{
+			"messages-to-relay": slice.Map(relayCandidateMsgs, func(msg chain.MessageWithSignatures) uint64 {
+				return msg.ID
+			}),
+		})
+		logger.Info("relaying messages")
+		err := p.ProcessMessages(ctx, queueName, relayCandidateMsgs)
+		if err != nil {
+			logger.WithFields(log.Fields{
+				"err":        err,
+				"queue-name": queueName,
+				"messages-to-relay": slice.Map(relayCandidateMsgs, func(msg chain.MessageWithSignatures) uint64 {
+					return msg.ID
+				}),
+			}).Error("error relaying messages")
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Relayer) ProvideEvidenceForMessages(ctx context.Context, queueName string, messagesInQueue []chain.MessageWithSignatures, p chain.Processor) error {
+	logger := log.WithFields(log.Fields{
+		"queue-name": queueName,
+	})
+
+	msgsToProvideEvidenceFor := slice.Filter(messagesInQueue, func(msg chain.MessageWithSignatures) bool {
+		return len(msg.PublicAccessData) > 0
+	})
+
+	if len(msgsToProvideEvidenceFor) > 0 {
+		logger := logger.WithFields(log.Fields{
+			"messages-to-provide-evidence-for": slice.Map(msgsToProvideEvidenceFor, func(msg chain.MessageWithSignatures) uint64 {
+				return msg.ID
+			}),
+		})
+		logger.Info("providing evidence for messages")
+		err := p.ProvideEvidence(ctx, queueName, msgsToProvideEvidenceFor)
+		if err != nil {
+			logger.WithError(err).Error("error providing evidence for messages")
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Relayer) Process(ctx context.Context, processors []chain.Processor) error {
+	var processErrors whoops.Group
+
+	if len(processors) == 0 {
+		return nil
+	}
 
 	// todo randomise
 	for _, p := range processors {
@@ -31,100 +131,49 @@ func (r *Relayer) Process(ctx context.Context, processors []chain.Processor) err
 				"queue-name": queueName,
 			})
 
-			// TODO: remove comments once signing is done on the paloma side.
-			queuedMessages, err := r.palomaClient.QueryMessagesForSigning(ctx, queueName)
-			loggerQueuedMessages := logger.WithFields(log.Fields{
-				"message-ids": slice.Map(queuedMessages, func(msg chain.QueuedMessage) uint64 {
-					return msg.ID
-				}),
-			})
-
-			if err != nil {
-				logger.Error("failed getting messages to sign")
-				return err
-			}
-
-			if len(queuedMessages) > 0 {
-				loggerQueuedMessages.Info("messages to sign")
-				signedMessages, err := p.SignMessages(ctx, queueName, queuedMessages...)
-				if err != nil {
-					loggerQueuedMessages.WithError(err).Error("unable to sign messages")
-					return err
-				}
-				loggerQueuedMessages = loggerQueuedMessages.WithFields(log.Fields{
-					"signed-messages": slice.Map(signedMessages, func(msg chain.SignedQueuedMessage) log.Fields {
-						return log.Fields{
-							"id": msg.ID,
-						}
-					}),
-				})
-				loggerQueuedMessages.Info("signed messages")
-
-				if err = r.broadcastSignatures(ctx, queueName, signedMessages); err != nil {
-					loggerQueuedMessages.WithError(err).Error("couldn't broadcast signatures and process attestation")
-					return err
-				}
-			}
-
-			msgsInQueue, err := r.palomaClient.QueryMessagesInQueue(ctx, queueName)
-
-			logger.Debug("got ", len(msgsInQueue), " messages from ", queueName)
-
-			relayCandidateMsgs := slice.Filter(
-				msgsInQueue,
-				func(msg chain.MessageWithSignatures) bool {
-					return len(msg.PublicAccessData) == 0
-				},
-				func(msg chain.MessageWithSignatures) bool {
-					return collision.AllowedToExecute(
-						ctx,
-						[]byte(fmt.Sprintf("%s-%d", queueName, msg.ID)),
-					)
-				},
-			)
-
-			msgsToProvideEvidenceFor := slice.Filter(msgsInQueue, func(msg chain.MessageWithSignatures) bool {
-				return len(msg.PublicAccessData) > 0
-			})
-
+			messagesInQueue, err := r.palomaClient.QueryMessagesInQueue(ctx, queueName)
+			logger.Debug("got ", len(messagesInQueue), " messages from ", queueName)
 			if err != nil {
 				logger.WithError(err).Error("couldn't get messages to relay")
 				return err
 			}
 
-			if len(relayCandidateMsgs) > 0 {
-				logger := logger.WithFields(log.Fields{
-					"messages-to-relay": slice.Map(relayCandidateMsgs, func(msg chain.MessageWithSignatures) uint64 {
-						return msg.ID
-					}),
-				})
-				logger.Info("relaying messages")
-				if err = p.ProcessMessages(ctx, queueName, relayCandidateMsgs); err != nil {
-					logger.WithFields(log.Fields{
-						"err":        err,
-						"queue-name": queueName,
-						"messages-to-relay": slice.Map(relayCandidateMsgs, func(msg chain.MessageWithSignatures) uint64 {
-							return msg.ID
-						}),
-					}).Error("error relaying messages")
-					return err
-				}
+			messagesForSigning, err := r.palomaClient.QueryMessagesForSigning(ctx, queueName)
+			if err != nil {
+				logger.Error("failed getting messages to sign")
+				return err
 			}
 
-			if len(msgsToProvideEvidenceFor) > 0 {
-				logger := logger.WithFields(log.Fields{
-					"messages-to-provide-evidence-for": slice.Map(msgsToProvideEvidenceFor, func(msg chain.MessageWithSignatures) uint64 {
-						return msg.ID
-					}),
-				})
-				logger.Info("providing evidence for messages")
-				if err = p.ProvideEvidence(ctx, queueName, msgsToProvideEvidenceFor); err != nil {
-					logger.WithError(err).Error("error providing evidence for messages")
-					return err
-				}
+			messagesForEvidence := messagesInQueue
+
+			// only pick 5 messages to relay at a time.  This protects against timeouts
+			messagesForRelaying := messagesInQueue
+			if len(messagesForRelaying) > 5 {
+				messagesForRelaying = messagesForRelaying[:5]
 			}
 
+			err = r.SignMessages(ctx, queueName, messagesForSigning, p)
+			if err != nil {
+				logger.Error("failed signing messages")
+				processErrors.Add(err)
+			}
+
+			err = r.ProvideEvidenceForMessages(ctx, queueName, messagesForEvidence, p)
+			if err != nil {
+				logger.Error("failed providing evidence for messages")
+				processErrors.Add(err)
+			}
+
+			err = r.RelayMessages(ctx, queueName, messagesForRelaying, p)
+			if err != nil {
+				logger.Error("failed relaying messages")
+				processErrors.Add(err)
+			}
 		}
+	}
+
+	if processErrors.Err() {
+		return processErrors
 	}
 
 	return nil

--- a/relayer/process.go
+++ b/relayer/process.go
@@ -144,27 +144,19 @@ func (r *Relayer) Process(ctx context.Context, processors []chain.Processor) err
 				return err
 			}
 
-			messagesForEvidence := messagesInQueue
-
-			// only pick 5 messages to relay at a time.  This protects against timeouts
-			messagesForRelaying := messagesInQueue
-			if len(messagesForRelaying) > 5 {
-				messagesForRelaying = messagesForRelaying[:5]
-			}
-
 			err = r.SignMessages(ctx, queueName, messagesForSigning, p)
 			if err != nil {
 				logger.Error("failed signing messages")
 				processErrors.Add(err)
 			}
 
-			err = r.ProvideEvidenceForMessages(ctx, queueName, messagesForEvidence, p)
+			err = r.ProvideEvidenceForMessages(ctx, queueName, messagesInQueue, p)
 			if err != nil {
 				logger.Error("failed providing evidence for messages")
 				processErrors.Add(err)
 			}
 
-			err = r.RelayMessages(ctx, queueName, messagesForRelaying, p)
+			err = r.RelayMessages(ctx, queueName, messagesInQueue, p)
 			if err != nil {
 				logger.Error("failed relaying messages")
 				processErrors.Add(err)

--- a/relayer/start.go
+++ b/relayer/start.go
@@ -3,11 +3,11 @@ package relayer
 import (
 	"context"
 	goerrors "errors"
+	"github.com/palomachain/pigeon/errors"
 	"sync"
 	"time"
 
 	"github.com/VolumeFi/whoops"
-	"github.com/palomachain/pigeon/errors"
 	"github.com/palomachain/pigeon/util/channels"
 	log "github.com/sirupsen/logrus"
 )
@@ -50,33 +50,7 @@ func (r *Relayer) Start(ctx context.Context) error {
 	log.Info("starting relayer")
 	var locker sync.Mutex
 
-	go func() {
-		ticker := time.NewTicker(defaultLoopTimeout)
-		defer ticker.Stop()
-
-		for range ticker.C {
-			processors, err := r.buildProcessors(ctx)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"err": err,
-				}).Error("couldn't build processors to update external chain info")
-
-				continue
-			}
-
-			log.Info("trying to update external chain info")
-
-			locker.Lock()
-			err = r.updateExternalChainInfos(ctx, processors)
-			locker.Unlock()
-
-			if err != nil {
-				log.WithFields(log.Fields{
-					"err": err,
-				}).Error("couldn't update external chain info. Will try again.")
-			}
-		}
-	}()
+	go r.startUpdateExternalChainInfos(ctx, &locker)
 
 	ticker := time.NewTicker(defaultLoopTimeout)
 	defer ticker.Stop()
@@ -84,50 +58,6 @@ func (r *Relayer) Start(ctx context.Context) error {
 	// only used to enter into the loop below immediately after the first "tick"
 	firstLoopEnter := make(chan time.Time, 1)
 	firstLoopEnter <- time.Time{}
-
-	process := func() error {
-		log.Info("relayer loop")
-		if ctx.Err() != nil {
-			log.Info("exiting relayer loop as context has ended")
-			return ctx.Err()
-		}
-
-		processors, err := r.buildProcessors(ctx)
-		if err != nil {
-			return err
-		}
-
-		locker.Lock()
-		err = r.Process(ctx, processors)
-		locker.Unlock()
-
-		switch {
-		case err == nil:
-			// success
-			return nil
-		case goerrors.Is(err, context.Canceled):
-			log.WithFields(log.Fields{
-				"err": err,
-			}).Debug("exited from the process loop due the context being canceled")
-			return nil
-		case goerrors.Is(err, context.DeadlineExceeded):
-			log.WithFields(log.Fields{
-				"err": err,
-			}).Debug("exited from the process loop due the context deadline being exceeded")
-			return nil
-		case errors.IsUnrecoverable(err):
-			// there is no way that we can recover from this
-			log.WithFields(log.Fields{
-				"err": err,
-			}).Error("unrecoverable error returned")
-			return err
-		default:
-			log.WithFields(log.Fields{
-				"err": err,
-			}).Error("error returned in process loop")
-			return nil
-		}
-	}
 
 	go func() {
 		r.startKeepAlive(ctx, &locker)
@@ -147,9 +77,81 @@ func (r *Relayer) Start(ctx context.Context) error {
 				}
 				return whoops.WrapS(ErrUnknown, "ticker channel for message processing was closed unexpectedly")
 			}
-			if err := process(); err != nil {
+			if err := r.process(ctx, &locker); err != nil {
 				log.WithError(err).Error("error while trying to process messages")
 			}
 		}
+	}
+}
+
+func (r *Relayer) startUpdateExternalChainInfos(ctx context.Context, locker sync.Locker) {
+	ticker := time.NewTicker(defaultLoopTimeout)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		processors, err := r.buildProcessors(ctx)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"err": err,
+			}).Error("couldn't build processors to update external chain info")
+
+			continue
+		}
+
+		log.Info("trying to update external chain info")
+
+		locker.Lock()
+		err = r.updateExternalChainInfos(ctx, processors)
+		locker.Unlock()
+
+		if err != nil {
+			log.WithFields(log.Fields{
+				"err": err,
+			}).Error("couldn't update external chain info. Will try again.")
+		}
+	}
+}
+
+func (r *Relayer) process(ctx context.Context, locker sync.Locker) error {
+	log.Info("relayer loop")
+	if ctx.Err() != nil {
+		log.Info("exiting relayer loop as context has ended")
+		return ctx.Err()
+	}
+
+	processors, err := r.buildProcessors(ctx)
+	if err != nil {
+		return err
+	}
+
+	locker.Lock()
+	err = r.Process(ctx, processors)
+	locker.Unlock()
+
+	switch {
+	case err == nil:
+		// success
+		return nil
+	case goerrors.Is(err, context.Canceled):
+		log.WithFields(log.Fields{
+			"err": err,
+		}).Debug("exited from the process loop due the context being canceled")
+		return nil
+	case goerrors.Is(err, context.DeadlineExceeded):
+		log.WithFields(log.Fields{
+			"err": err,
+		}).Debug("exited from the process loop due the context deadline being exceeded")
+		return nil
+	case errors.IsUnrecoverable(err):
+		// there is no way that we can recover from this
+		log.WithFields(log.Fields{
+			"err": err,
+		}).Error("unrecoverable error returned")
+		return err
+	default:
+		log.WithFields(log.Fields{
+			"err": err,
+		}).Error("error returned in process loop")
+		return nil
 	}
 }


### PR DESCRIPTION
Closes https://github.com/VolumeFi/paloma/issues/268

# Background

This is in response to some behavior we saw when there were lots of messages in the queue.  They were being very slowly churned through and we didn't understand why.  Here's what was happening:

When pigeon runs process, it's doing three things.
1. Sign messages
2. Relay messages
3. Provide evidence for messages

We thought that failing jobs weren't getting deleted from the queue, but they actually do if Pigeon is able to report back regularly that it tried relaying and failed.

The problem is, Pigeon was getting stuck at relaying messages and hanging too long.  It would then return an error and never get to the step where it provides evidence.  That is, until there were no more messages left that needed relayed.  This is why we saw a very slow, but existent processing of queue messages.

#### I've provided two functional changes that put us into a better state.  

1. Now, we sign and provide evidence before trying to relay.  That way, if we time out on relay, the other two already succeeded.
2. All three steps of processing are now attempted, even if prior steps fail.


#### Work in this PR:
* Split the process function into the three separate pieces of work it's doing
* Reorder the work in the process function to perform the faster pieces first
* If one part of process fails, execute the other two before returning an error
* Refactored the start function to remove inline functions.  This will be helpful in a later iteration when we spin off more goroutines for the different pieces of work

# Testing completed

- [x] This was tested in a local private testnet and the desired part of functionality remains the same