### PR TITLE
Ticking every 10 seconds for faster processing of new messages

### DIFF
--- a/chain/paloma/wrappers.go
+++ b/chain/paloma/wrappers.go
@@ -2,6 +2,7 @@ package paloma
 
 import (
 	"context"
+
 	"github.com/VolumeFi/whoops"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/grpc"

--- a/chain/paloma/wrappers.go
+++ b/chain/paloma/wrappers.go
@@ -2,8 +2,6 @@ package paloma
 
 import (
 	"context"
-	"time"
-
 	"github.com/VolumeFi/whoops"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/grpc"
@@ -42,7 +40,6 @@ func (g GRPCClientDowner) NewStream(ctx context.Context, desc *ggrpc.StreamDesc,
 }
 
 func (m MessageSenderDowner) SendMsg(ctx context.Context, msg sdk.Msg, memo string) (*sdk.TxResponse, error) {
-	time.Sleep(10 * time.Second)
 	log.Debug("Sending Msg: ", msg)
 	res, err := m.W.SendMsg(ctx, msg, memo)
 

--- a/relayer/start.go
+++ b/relayer/start.go
@@ -11,9 +11,9 @@ import (
 
 const (
 	updateExternalChainsLoopInterval = 1 * time.Minute
-	signMessagesLoopInterval         = 1 * time.Minute
-	relayMessagesLoopInterval        = 1 * time.Minute
-	attestMessagesLoopInterval       = 1 * time.Minute
+	signMessagesLoopInterval         = 10 * time.Second
+	relayMessagesLoopInterval        = 10 * time.Second
+	attestMessagesLoopInterval       = 10 * time.Second
 )
 
 func (r *Relayer) waitUntilStaking(ctx context.Context) error {
@@ -64,7 +64,7 @@ func (r *Relayer) Start(ctx context.Context) error {
 		return err
 	}
 
-	log.Info("starting relayer")
+	log.Info("starting pigeon")
 	var locker sync.Mutex
 
 	// Start background goroutines to run separately from each other


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/299

# Background

Remove the sleep.  After some testing, it appears that previous changes
have fixed the account sequence mismatch errors.  Pigeon still needs the
locks in place so that it doesn't run over itself, but as long as one
message is in flight at a time, there are no more errors with account
sequence mismatch

One caveat to this.  If another actor uses the validator account key, we will
still see account sequence mismatch errors.  The validator account key needs to
belong solely to Pigeon

# Testing completed

- [x] Tested on a local private testnet
