### PR TITLE
Loop every second

### DIFF
--- a/relayer/start.go
+++ b/relayer/start.go
@@ -11,9 +11,9 @@ import (
 
 const (
 	updateExternalChainsLoopInterval = 1 * time.Minute
-	signMessagesLoopInterval         = 10 * time.Second
-	relayMessagesLoopInterval        = 10 * time.Second
-	attestMessagesLoopInterval       = 10 * time.Second
+	signMessagesLoopInterval         = 1 * time.Second
+	relayMessagesLoopInterval        = 1 * time.Second
+	attestMessagesLoopInterval       = 1 * time.Second
 )
 
 func (r *Relayer) waitUntilStaking(ctx context.Context) error {


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/299

# Background

We arbitrarily chose 10 seconds as a baseline for more speed.  There's no reason we can't go faster though.  State is only committed each block (~5.6s), but if we loop faster, we have a good chance of picking up work from the current block and submitting it in the very next block.

# Testing completed

- [x] tested in a local private testnet