### PR TITLE
Continue checking if a pigeon is staking

### DIFF
--- a/chain/errors.go
+++ b/chain/errors.go
@@ -21,5 +21,5 @@ const (
 	EnrichedID               whoops.Field[uint64] = "id"
 	EnrichedItemType         whoops.Field[string] = "type"
 
-	ErrNotValidator = whoops.String("not a validator")
+	ErrNotValidator = whoops.String("not a validator in current snapshot")
 )

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -68,6 +68,8 @@ type Relayer struct {
 
 	chainsInfos []evmtypes.ChainInfo
 	processors  []chain.Processor
+
+	staking bool
 }
 
 type Config struct {
@@ -82,5 +84,6 @@ func New(config config.Root, palomaClient PalomaClienter, evmFactory EvmFactorie
 		evmFactory:    evmFactory,
 		time:          customTime,
 		relayerConfig: cfg,
+		staking:       false,
 	}
 }

--- a/relayer/start.go
+++ b/relayer/start.go
@@ -2,7 +2,6 @@ package relayer
 
 import (
 	"context"
-	goerrors "errors"
 	"sync"
 	"time"
 
@@ -14,31 +13,27 @@ const (
 	signMessagesLoopInterval         = 1 * time.Second
 	relayMessagesLoopInterval        = 1 * time.Second
 	attestMessagesLoopInterval       = 1 * time.Second
+	checkStakingLoopInterval         = 5 * time.Second
 )
 
-func (r *Relayer) waitUntilStaking(ctx context.Context) error {
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		err := r.isStaking(ctx)
-		switch {
-		case err == nil:
-			// validator is staking
-			log.Info("validator is staking")
-			return nil
-		case goerrors.Is(err, ErrValidatorIsNotStaking):
-			// does nothing
-			log.Info("not staking. waiting")
-		default:
-			return err
-		}
-
-		time.Sleep(5 * time.Second)
+func (r *Relayer) checkStaking(ctx context.Context, locker sync.Locker) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
+	log.Info("checking if validator is staking")
+
+	err := r.isStaking(ctx)
+	if err == nil {
+		log.Info("validator is staking")
+		r.staking = true
+	} else {
+		log.Error("validator is not staking")
+		r.staking = false
+	}
+	return nil
 }
 
-func (r *Relayer) startProcess(ctx context.Context, locker sync.Locker, tickerInterval time.Duration, process func(context.Context, sync.Locker) error) {
+func (r *Relayer) startProcess(ctx context.Context, locker sync.Locker, tickerInterval time.Duration, requiresStaking bool, process func(context.Context, sync.Locker) error) {
 	ticker := time.NewTicker(tickerInterval)
 	defer ticker.Stop()
 
@@ -49,9 +44,11 @@ func (r *Relayer) startProcess(ctx context.Context, locker sync.Locker, tickerIn
 			logger.Warn("exiting due to context being done")
 			return
 		case <-ticker.C:
-			err := process(ctx, locker)
-			if err != nil {
-				logger.Error(err)
+			if !requiresStaking || r.staking {
+				err := process(ctx, locker)
+				if err != nil {
+					logger.Error(err)
+				}
 			}
 		}
 	}
@@ -60,20 +57,19 @@ func (r *Relayer) startProcess(ctx context.Context, locker sync.Locker, tickerIn
 // Start starts the relayer. It's responsible for handling the communication
 // with Paloma and other chains.
 func (r *Relayer) Start(ctx context.Context) error {
-	if err := r.waitUntilStaking(ctx); err != nil {
-		return err
-	}
-
 	log.Info("starting pigeon")
 	var locker sync.Mutex
 
+	_ = r.checkStaking(ctx, &locker)
+
 	// Start background goroutines to run separately from each other
-	go r.startProcess(ctx, &locker, updateExternalChainsLoopInterval, r.UpdateExternalChainInfos)
-	go r.startProcess(ctx, &locker, signMessagesLoopInterval, r.SignMessages)
-	go r.startProcess(ctx, &locker, relayMessagesLoopInterval, r.RelayMessages)
-	go r.startProcess(ctx, &locker, attestMessagesLoopInterval, r.AttestMessages)
+	go r.startProcess(ctx, &locker, checkStakingLoopInterval, false, r.checkStaking)
+	go r.startProcess(ctx, &locker, updateExternalChainsLoopInterval, true, r.UpdateExternalChainInfos)
+	go r.startProcess(ctx, &locker, signMessagesLoopInterval, true, r.SignMessages)
+	go r.startProcess(ctx, &locker, relayMessagesLoopInterval, true, r.RelayMessages)
+	go r.startProcess(ctx, &locker, attestMessagesLoopInterval, true, r.AttestMessages)
 
 	// Start the foreground process
-	r.startProcess(ctx, &locker, r.relayerConfig.KeepAliveLoopTimeout, r.keepAlive)
+	r.startProcess(ctx, &locker, r.relayerConfig.KeepAliveLoopTimeout, false, r.keepAlive)
 	return nil
 }


### PR DESCRIPTION
# Related Github tickets

- Needed because of https://github.com/VolumeFi/paloma/issues/299

# Background

Previously, this was only checked at startup.  The problem is, pigeons get jailed all the time while they're still running.  The check is never re-checked and the pigeon keeps trying to send messages to Paloma that will just be rejected.  This becomes more of a problem now that we're looping much faster and sending more messages.

Now, we check in with Paloma every 5 seconds to make sure our pigeon is still staking.  If it's not staking, it doesn't bother trying to do work that will just be rejected.

The one exception to this is the keep_alive.  We so aggressively jail pigeons that I don't want anything delaying a keep_alive message.  We can fire them off and let them fail when jailed.

# Testing completed

- [x] Tested in a local private testnet