### PR TITLE
Upgrade to paloma v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.11.6
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
-	github.com/palomachain/paloma v0.11.5-0.20230613170335-a165a4645595
+	github.com/palomachain/paloma v1.3.0
 	github.com/sirupsen/logrus v1.9.2
 	github.com/spf13/cobra v1.7.0
 	github.com/strangelove-ventures/lens v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -865,8 +865,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
-github.com/palomachain/paloma v0.11.5-0.20230613170335-a165a4645595 h1:HbD5dTeKmCnRwVMW1y7ysMsQRxISynoN7/cvC01KrWc=
-github.com/palomachain/paloma v0.11.5-0.20230613170335-a165a4645595/go.mod h1:Egc6cv++ZQ/PUYooJFBLIINhBSRiIRRDXPkNkujmF6c=
+github.com/palomachain/paloma v1.3.0 h1:ZykbG3ol/+WNOlnFE4NmuABgTh3l6ZoqTVKoouqCFVY=
+github.com/palomachain/paloma v1.3.0/go.mod h1:Egc6cv++ZQ/PUYooJFBLIINhBSRiIRRDXPkNkujmF6c=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
# Background

We were previously pointing to a commit of paloma in order to get the latest changes.  Now there's a new release, so let's point to that.  These are equivalent in functionality

# Testing completed

- [x] Tested in a local private testnet