### PR TITLE
Upgrade release script to go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@
 ###########################
 ####     Base image    ####
 ###########################
-FROM golang:1.18-stretch AS base
-MAINTAINER Matija Martinic <matija@volume.finance>
+FROM golang:1.20-bullseye AS base
 WORKDIR /app
 
 ###########################


### PR DESCRIPTION
This has already been merged into the release branch, but we need it in master as well.  Here's the master PR.

The release was broken due to the most recent upgraded dependencies.  We were getting this error:

```
/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/types/address.go:88:26: undefined: atomic.Bool
note: module requires Go 1.19
/go/pkg/mod/github.com/ethereum/go-ethereum@v1.12.0/metrics/counter.go:118:15: undefined: atomic.Int64
/go/pkg/mod/github.com/ethereum/go-ethereum@v1.12.0/metrics/counter_float64.go:119:19: undefined: atomic.Uint64
/go/pkg/mod/github.com/ethereum/go-ethereum@v1.12.0/metrics/counter_float64.go:147:35: undefined: atomic.Uint64
/go/pkg/mod/github.com/ethereum/go-ethereum@v1.12.0/metrics/ewma.go:78:19: undefined: atomic.Int64
/go/pkg/mod/github.com/ethereum/go-ethereum@v1.12.0/metrics/gauge.go:104:15: undefined: atomic.Int64
/go/pkg/mod/github.com/ethereum/go-ethereum@v1.12.0/metrics/gauge_float64.go:89:19: undefined: atomic.Uint64
/go/pkg/mod/github.com/ethereum/go-ethereum@v1.12.0/metrics/meter.go:104:40: undefined: atomic.Int64
/go/pkg/mod/github.com/ethereum/go-ethereum@v1.12.0/metrics/meter.go:172:21: undefined: atomic.Bool
note: module requires Go 1.19
/go/pkg/mod/github.com/ethereum/go-ethereum@v1.12.0/core/vm/evm.go:117:15: undefined: atomic.Bool
note: module requires Go 1.19
```

We should go ahead and upgrade to 1.20 to be at the most recent
