### PR TITLE
Fixing goreleaser config for removed functionality

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,13 +17,11 @@ builds:
       - amd64
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
# Background

This has been deprecated, and as of the lastest release has been removed.  We have to make this change in order for the latest goreleaser to build

More info: https://goreleaser.com/deprecations/#archivesreplacements

# Testing completed

- [x] Ran a build locally