### PR TITLE
Support for pigeon message assigning in Paloma

### DIFF
--- a/chain/errors.go
+++ b/chain/errors.go
@@ -20,6 +20,4 @@ const (
 	EnrichedChainReferenceID whoops.Field[string] = "chainReferenceID"
 	EnrichedID               whoops.Field[uint64] = "id"
 	EnrichedItemType         whoops.Field[string] = "type"
-
-	ErrNotValidator = whoops.String("not a validator in current snapshot")
 )

--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -411,16 +411,6 @@ func (t compass) processMessages(ctx context.Context, queueTypeName string, msgs
 			break
 		}
 
-		if len(rawMsg.ErrorData) > 0 {
-			logger.Warn("skipping the message as it already has error data")
-			continue
-		}
-
-		if len(rawMsg.PublicAccessData) > 0 {
-			logger.Warn("skipping the message as it already has public access data")
-			continue
-		}
-
 		var processingErr error
 		var tx *ethtypes.Transaction
 		msg := rawMsg.Msg.(*types.Message)

--- a/go.mod
+++ b/go.mod
@@ -193,3 +193,5 @@ require (
 )
 
 replace github.com/strangelove-ventures/lens => github.com/volumefi/lens-1 v0.5.5
+
+replace github.com/palomachain/paloma => github.com/volumefi/paloma v1.3.2-0.20230705171534-3388a4fb3d69

--- a/go.sum
+++ b/go.sum
@@ -874,8 +874,6 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
-github.com/palomachain/paloma v1.3.1 h1:Dlb+s7qXFTSp+GgE0zkPHz1uAsYZDzu7XwZ8V+MgZ4k=
-github.com/palomachain/paloma v1.3.1/go.mod h1:E2hK4s85dOPwPl9z/bk9VmXgN34jrgtLyBj79eoWDDY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1047,6 +1045,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa h1:5SqCsI/2Qya2bCzK15ozrqo2sZxkh0FHynJZOTVoV6Q=
 github.com/volumefi/lens-1 v0.5.5 h1:OmSZOXRn7gsVuQ2ucjoEObIgPRD8D/RYPzcCHgmFclQ=
 github.com/volumefi/lens-1 v0.5.5/go.mod h1:6PdiMJFYkr4Mm3ioZ4UdidpQ1o9lspP0qX31NUsacF4=
+github.com/volumefi/paloma v1.3.2-0.20230705171534-3388a4fb3d69 h1:fee/5sHLgno1RsvhXZVKmYlMU1fk5q9y34cvjJxX8Fs=
+github.com/volumefi/paloma v1.3.2-0.20230705171534-3388a4fb3d69/go.mod h1:E2hK4s85dOPwPl9z/bk9VmXgN34jrgtLyBj79eoWDDY=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=

--- a/relayer/message_attester.go
+++ b/relayer/message_attester.go
@@ -56,18 +56,14 @@ func (r *Relayer) attestMessages(ctx context.Context, processors []chain.Process
 				return err
 			}
 
-			msgsToAttest := slice.Filter(messagesInQueue, func(msg chain.MessageWithSignatures) bool {
-				return len(msg.PublicAccessData) > 0 || len(msg.ErrorData) > 0
-			})
-
-			if len(msgsToAttest) > 0 {
+			if len(messagesInQueue) > 0 {
 				logger := logger.WithFields(log.Fields{
-					"messages-to-attest": slice.Map(msgsToAttest, func(msg chain.MessageWithSignatures) uint64 {
+					"messages-to-attest": slice.Map(messagesInQueue, func(msg chain.MessageWithSignatures) uint64 {
 						return msg.ID
 					}),
 				})
-				logger.Info("attesting ", len(msgsToAttest), " messages")
-				err := p.ProvideEvidence(ctx, queueName, msgsToAttest)
+				logger.Info("attesting ", len(messagesInQueue), " messages")
+				err := p.ProvideEvidence(ctx, queueName, messagesInQueue)
 				if err != nil {
 					logger.WithError(err).Error("error attesting messages")
 					return err

--- a/relayer/message_attester_test.go
+++ b/relayer/message_attester_test.go
@@ -78,8 +78,6 @@ func TestAttestMessages(t *testing.T) {
 				}, nil)
 				pal.On("QueryMessagesForAttesting", mock.Anything, mock.Anything).Return(
 					[]chain.MessageWithSignatures{
-						{QueuedMessage: chain.QueuedMessage{ID: 123}},
-						{QueuedMessage: chain.QueuedMessage{ID: 456}},
 						{QueuedMessage: chain.QueuedMessage{ID: 789, PublicAccessData: []byte("tx hash")}},
 					},
 					nil,

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -28,32 +28,9 @@ func (r *Relayer) RelayMessages(ctx context.Context, locker sync.Locker) error {
 	return handleProcessError(err)
 }
 
-func (r *Relayer) getMsgOffsetData(ctx context.Context) (int, int, error) {
-	snapshot, err := r.palomaClient.QueryGetSnapshotByID(ctx, 0)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	numValidators := len(snapshot.Validators)
-	for i, validator := range snapshot.Validators {
-		if r.palomaClient.GetValidatorAddress().String() == validator.Address.String() {
-			return numValidators, i, nil
-		}
-	}
-
-	// If we made it here, somehow our validator address wasn't in the snapshot
-	return 0, 0, chain.ErrNotValidator
-}
-
 func (r *Relayer) relayMessages(ctx context.Context, processors []chain.Processor) error {
 	if len(processors) == 0 {
 		return nil
-	}
-
-	// Get the offset for this validator so that we know which messages to relay
-	numValidators, myMsgOffset, err := r.getMsgOffsetData(ctx)
-	if err != nil {
-		return err
 	}
 
 	// todo randomise
@@ -79,32 +56,19 @@ func (r *Relayer) relayMessages(ctx context.Context, processors []chain.Processo
 				return err
 			}
 
-			relayCandidateMsgs := slice.Filter(
-				messagesInQueue,
-				func(msg chain.MessageWithSignatures) bool {
-					return len(msg.PublicAccessData) == 0
-				},
-				func(msg chain.MessageWithSignatures) bool {
-					return len(msg.ErrorData) == 0
-				},
-				func(msg chain.MessageWithSignatures) bool {
-					return (int(msg.ID) % numValidators) == myMsgOffset
-				},
-			)
-
-			if len(relayCandidateMsgs) > 0 {
+			if len(messagesInQueue) > 0 {
 				logger := logger.WithFields(log.Fields{
-					"messages-to-relay": slice.Map(relayCandidateMsgs, func(msg chain.MessageWithSignatures) uint64 {
+					"messages-to-relay": slice.Map(messagesInQueue, func(msg chain.MessageWithSignatures) uint64 {
 						return msg.ID
 					}),
 				})
-				logger.Info("relaying ", len(relayCandidateMsgs), " messages")
-				err := p.ProcessMessages(ctx, queueName, relayCandidateMsgs)
+				logger.Info("relaying ", len(messagesInQueue), " messages")
+				err := p.ProcessMessages(ctx, queueName, messagesInQueue)
 				if err != nil {
 					logger.WithFields(log.Fields{
 						"err":        err,
 						"queue-name": queueName,
-						"messages-to-relay": slice.Map(relayCandidateMsgs, func(msg chain.MessageWithSignatures) uint64 {
+						"messages-to-relay": slice.Map(messagesInQueue, func(msg chain.MessageWithSignatures) uint64 {
 							return msg.ID
 						}),
 					}).Error("error relaying messages")

--- a/relayer/start.go
+++ b/relayer/start.go
@@ -27,7 +27,7 @@ func (r *Relayer) checkStaking(ctx context.Context, locker sync.Locker) error {
 		log.Info("validator is staking")
 		r.staking = true
 	} else {
-		log.Error("validator is not staking")
+		log.Info("validator is not staking... waiting")
 		r.staking = false
 	}
 	return nil


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/342
- https://github.com/VolumeFi/paloma/issues/118
- https://github.com/palomachain/paloma/pull/900

# Background

* Pigeons no longer decide which messages to run, they are assigned messages to run
* Pigeons are becomming dumber.  The logic of which messages are ready for relaying or attesting is being moved into Paloma
* Some log levels were updated to reflect what the logs really mean
* Temporarily pointing to the volumefi paloma code because there is a corresponding PR we need types from.  We'll update this to the new version once there is one.

# Testing completed

- [x] Tests were updated to match the new functionality
- [x] Tested on a local private testnet