### PR TITLE
Removing unnecessary output in logs using Println

### DIFF
--- a/chain/evm/deploy_contract.go
+++ b/chain/evm/deploy_contract.go
@@ -2,7 +2,6 @@ package evm
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 
 	"github.com/VolumeFi/whoops"
@@ -117,8 +116,6 @@ func deployContract(
 
 		logger.Info("deploying contract")
 
-		fmt.Printf("[deploySmartContractToChain] UNPACK ERR: %v\n", err)
-		fmt.Printf("[deploySmartContractToChain] UNPACK ARGS: %+v\n", constructorArgs)
 		contractAddr, tx, _, err = bind.DeployContract(
 			txOpts,
 			contractAbi,
@@ -128,8 +125,6 @@ func deployContract(
 		)
 		constructorArgs, _ = contractAbi.Constructor.Inputs.Unpack(constructorInput)
 
-		fmt.Printf("[deploySmartContractToChain-after bind.DeployContract] UNPACK ERR: %v\n", err)
-		fmt.Printf("[deploySmartContractToChain-after bind.DeployContract] UNPACK ARGS: %+v\n", constructorArgs)
 		whoops.Assert(err)
 		if tx.Type() == 2 {
 			logger.WithFields(log.Fields{


### PR DESCRIPTION
# Background

This output looks like it was put in a long time ago while debugging.  It's not using the log package, and it doesn't look like useful information to log.  Removing it to clean up our logs a bit.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
