### PR TITLE
hack: support kava-main

### DIFF
--- a/chain/evm/processor.go
+++ b/chain/evm/processor.go
@@ -148,6 +148,10 @@ func (p Processor) IsRightChain(ctx context.Context) error {
 		return err
 	}
 
+	if p.chainReferenceID == "kava-main" {
+		return p.isRightChain(common.HexToHash("0x76966b1d12b21d3ff22578948b05a42b3da5766fcc4b17ea48da5a154c80f08b"))
+	}
+
 	return p.isRightChain(block.Hash())
 }
 


### PR DESCRIPTION


# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/478

# Background

Kava uses tendermint hashes for all of its block hashes, which results in problems when trying to recalculate them automatically.

Until we have proper support for parallel EVM client implementations, we're going to add a hack which circumvents the actual block hash recalculation in case the target chain is kava-main

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
