### PR TITLE
Fixing typo in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,7 @@ builds:
 archives:
   - name_template: >-
       {{ .ProjectName }}_
-      {{- title .Os }}
+      {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}
     files:


### PR DESCRIPTION
# Background

We also had this in Paloma.  It was fixed there, but we forgot to fix it here.  This affects the naming convention of the release files.
