### PR TITLE
fix: 🔧 Ensure v-prefixed version report

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	gotime "time"
@@ -47,7 +48,13 @@ var (
 	commit  = ""
 )
 
-func Version() string { return version }
+func Version() string {
+	if !strings.HasPrefix(version, "v") {
+		version = fmt.Sprintf("v%s", version)
+	}
+
+	return version
+}
 
 func Commit() string { return commit }
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/573

# Background

Package semver implements comparison of semantic version strings. In this package, semantic version strings must begin with a leading "v", as in "v1.0.0". Our current keep-alive implementation fails if the version is not prefixed with a `v`.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
