### PR TITLE
feat: add blxr client and pigeon trait

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -60,7 +60,6 @@ func Commit() string { return commit }
 
 func Relayer() *relayer.Relayer {
 	if _relayer == nil {
-		// do something
 		_relayer = relayer.New(
 			*Config(),
 			*PalomaClient(),

--- a/chain/paloma/client.go
+++ b/chain/paloma/client.go
@@ -330,6 +330,7 @@ type ChainInfoIn struct {
 	ChainReferenceID string
 	AccAddress       string
 	PubKey           []byte
+	Traits           []string
 }
 
 // AddExternalChainInfo adds info about the external chain. It adds the chain's
@@ -351,6 +352,7 @@ func (c Client) AddExternalChainInfo(ctx context.Context, chainInfos ...ChainInf
 				ChainReferenceID: in.ChainReferenceID,
 				Address:          in.AccAddress,
 				Pubkey:           in.PubKey,
+				Traits:           in.Traits,
 			}
 		},
 	)

--- a/cmd/pigeon/cmd_start.go
+++ b/cmd/pigeon/cmd_start.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/palomachain/pigeon/app"
 	"github.com/palomachain/pigeon/health"
+	"github.com/palomachain/pigeon/internal/mev"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -55,6 +56,8 @@ var startCmd = &cobra.Command{
 
 		relayer := app.Relayer()
 		relayer.SetAppVersion(app.Version())
+		relayer.SetMevClient(mev.New(app.Config()))
+
 		err = relayer.Start(ctx)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,8 @@ type CosmosSpecificClientConfig struct {
 }
 
 type EVMSpecificClientConfig struct {
-	TxType uint8 `yaml:"tx-type"`
+	TxType                      uint8 `yaml:"tx-type"`
+	BloxrouteIntegrationEnabled bool  `yaml:"bloxroute-mev-enabled"`
 }
 
 type ChainClientConfig struct {
@@ -46,6 +47,8 @@ func (f Filepath) Path() string {
 
 type Root struct {
 	HealthCheckPortRaw int `yaml:"health-check-port"`
+
+	BloxrouteAuthorizationHeader string `yaml:"bloxroute-auth-header"`
 
 	Paloma Paloma `yaml:"paloma"`
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/ethereum/go-ethereum v1.11.6
+	github.com/go-resty/resty/v2 v2.7.0
+	github.com/jarcoal/httpmock v1.3.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/palomachain/paloma v1.6.1
@@ -198,5 +200,6 @@ require (
 replace (
 	// Link to op-geth, which is built on top of go-ethereum
 	github.com/ethereum/go-ethereum v1.11.6 => github.com/ethereum-optimism/op-geth v1.101106.0-rc.2
+	github.com/palomachain/paloma => github.com/volumefi/paloma v1.5.0-next.0.20230809143041-f87d7e38d87a
 	github.com/strangelove-ventures/lens => github.com/volumefi/lens-1 v0.5.5
 )

--- a/go.sum
+++ b/go.sum
@@ -484,6 +484,8 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/jYrnRPArHwAcmLoJZxyho=
 github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
+github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
+github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
@@ -716,6 +718,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
+github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
+github.com/jarcoal/httpmock v1.3.0/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
@@ -794,6 +798,7 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643/go.mod h1:43+3pMjjKimDBf5Kr4ZFNGbLql1zKkbImw+fZbw3geM=
 github.com/mimoo/StrobeGo v0.0.0-20210601165009-122bf33a46e0 h1:QRUSJEgZn2Snx0EmT/QLXibWjSUDjKWvXIT19NBVp94=
@@ -873,8 +878,6 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
-github.com/palomachain/paloma v1.6.1 h1:mgBIOjw8rmBtCLi4+B/nSgJ3Wy0h0RJRmTN07xfSI/I=
-github.com/palomachain/paloma v1.6.1/go.mod h1:cVx5Y9GBsbgD3JGsv9hP6XkAUarpl6TUmxmAxQyX9Ho=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1044,6 +1047,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa h1:5SqCsI/2Qya2bCzK15ozrqo2sZxkh0FHynJZOTVoV6Q=
 github.com/volumefi/lens-1 v0.5.5 h1:OmSZOXRn7gsVuQ2ucjoEObIgPRD8D/RYPzcCHgmFclQ=
 github.com/volumefi/lens-1 v0.5.5/go.mod h1:6PdiMJFYkr4Mm3ioZ4UdidpQ1o9lspP0qX31NUsacF4=
+github.com/volumefi/paloma v1.5.0-next.0.20230809143041-f87d7e38d87a h1:h0k5Hhvtvhj61OMBnvw3QF4x0ZvEDzL4CXVsAom8fLs=
+github.com/volumefi/paloma v1.5.0-next.0.20230809143041-f87d7e38d87a/go.mod h1:Aw6HM2YbgJ3edjd1TsUKz9/1SDMGZAofv8zWuDSjofk=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
@@ -1197,6 +1202,7 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/internal/mev/blxr/client.go
+++ b/internal/mev/blxr/client.go
@@ -7,8 +7,10 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-const cHealthprobeQueryInterval = time.Second
-const cBloXRouteCloudAPIURL = "https://api.blxrbdn.com"
+const (
+	cHealthprobeQueryInterval = time.Second
+	cBloXRouteCloudAPIURL     = "https://api.blxrbdn.com"
+)
 
 var chainIDLookup = map[string]string{
 	"eth-main":   "Mainnet",

--- a/internal/mev/blxr/client.go
+++ b/internal/mev/blxr/client.go
@@ -1,0 +1,57 @@
+package blxr
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
+
+const cHealthprobeQueryInterval = time.Second
+const cBloXRouteCloudAPIURL = "https://api.blxrbdn.com"
+
+var chainIDLookup = map[string]string{
+	"eth-main":   "Mainnet",
+	"bnb-main":   "BSC-Mainnet",
+	"matic-main": "Polygon-Mainnet",
+}
+
+type Client struct {
+	authHeader string
+	isHealthy  bool
+	chains     map[string]struct{}
+	rs         *resty.Client
+}
+
+func New(authHeader string) *Client {
+	return &Client{
+		authHeader: authHeader,
+		chains:     make(map[string]struct{}),
+		rs:         resty.New(),
+	}
+}
+
+func (c *Client) IsHealthy() bool {
+	return c.isHealthy
+}
+
+func (c *Client) RegisterChain(referenceChainID string) {
+	blxrID, fnd := chainIDLookup[referenceChainID]
+	if !fnd {
+		panic(fmt.Errorf("chain %s not supported for bloXroute MEV support", referenceChainID))
+	}
+	if _, fnd := c.chains[blxrID]; fnd {
+		panic(fmt.Errorf("chain %s already has an MEV RPC endpoint registered", blxrID))
+	}
+	c.chains[blxrID] = struct{}{}
+}
+
+func (c *Client) IsChainRegistered(referenceChainID string) bool {
+	blxrID, fnd := chainIDLookup[referenceChainID]
+	if !fnd {
+		panic(fmt.Errorf("chain %s not supported for bloXroute MEV support", referenceChainID))
+	}
+
+	_, fnd = c.chains[blxrID]
+	return fnd
+}

--- a/internal/mev/blxr/client_test.go
+++ b/internal/mev/blxr/client_test.go
@@ -1,0 +1,87 @@
+package blxr_test
+
+import (
+	"testing"
+
+	"github.com/palomachain/pigeon/internal/mev/blxr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientRegisterChain(t *testing.T) {
+	c := blxr.New("auth")
+	tests := []struct {
+		name          string
+		chainID       string
+		expectedPanic bool
+	}{
+		{
+			name:          "with eth",
+			chainID:       "eth-main",
+			expectedPanic: false,
+		},
+		{
+			name:          "with bnb",
+			chainID:       "bnb-main",
+			expectedPanic: false,
+		},
+		{
+			name:          "with matic",
+			chainID:       "matic-main",
+			expectedPanic: false,
+		},
+		{
+			name:          "with double registry chain",
+			chainID:       "eth-main",
+			expectedPanic: true,
+		},
+		{
+			name:          "with unsupported chain",
+			chainID:       "kava-main",
+			expectedPanic: true,
+		},
+	}
+
+	for _, v := range tests {
+		if v.expectedPanic {
+			require.Panics(t, func() { c.RegisterChain(v.chainID) }, v.name)
+		} else {
+			require.NotPanics(t, func() { c.RegisterChain(v.chainID) }, v.name)
+		}
+	}
+}
+
+func TestClientIsChainRegistered(t *testing.T) {
+	c := blxr.New("auth")
+	tests := []struct {
+		name         string
+		chainID      string
+		expectedFind bool
+	}{
+		{
+			name:         "with eth",
+			chainID:      "eth-main",
+			expectedFind: true,
+		},
+		{
+			name:         "with bnb",
+			chainID:      "bnb-main",
+			expectedFind: true,
+		},
+		{
+			name:         "with matic",
+			chainID:      "matic-main",
+			expectedFind: false,
+		},
+	}
+
+	c.RegisterChain("eth-main")
+	c.RegisterChain("bnb-main")
+
+	for _, v := range tests {
+		require.Equal(t, v.expectedFind, c.IsChainRegistered(v.chainID), v.name)
+	}
+
+	t.Run("with not supported chain type", func(t *testing.T) {
+		require.Panics(t, func() { c.IsChainRegistered("kava-main") })
+	})
+}

--- a/internal/mev/blxr/health.go
+++ b/internal/mev/blxr/health.go
@@ -1,0 +1,46 @@
+package blxr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func (c *Client) KeepAlive(ctx context.Context, locker sync.Locker) error {
+	locker.Lock()
+	defer locker.Unlock()
+	return c.runHealthCheck(ctx)
+}
+
+func (c *Client) runHealthCheck(ctx context.Context) error {
+	res, err := c.rs.R().SetContext(ctx).
+		SetHeader("Authorization", c.authHeader).
+		SetBody(map[string]interface{}{"method": "ping", "id": "1", "params": nil}).
+		Post(cBloXRouteCloudAPIURL)
+
+	if err != nil || res.StatusCode() != http.StatusOK {
+		if c.IsHealthy() {
+			log.WithContext(ctx).
+				WithField("status code", res.StatusCode()).
+				WithError(err).
+				Warnf("Blxr client lost connection. Pigeon EVM relayer traits unhealthy.")
+			c.isHealthy = false
+		}
+		return fmt.Errorf("BLXR client unhealthy: %w", err)
+	}
+
+	if !c.IsHealthy() {
+		log.WithContext(ctx).Infof("Blxr client recovered.")
+		c.isHealthy = true
+	}
+
+	return nil
+}
+
+func (c *Client) GetHealthprobeInterval() time.Duration {
+	return cHealthprobeQueryInterval
+}

--- a/internal/mev/blxr/health.go
+++ b/internal/mev/blxr/health.go
@@ -10,9 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (c *Client) KeepAlive(ctx context.Context, locker sync.Locker) error {
-	locker.Lock()
-	defer locker.Unlock()
+func (c *Client) KeepAlive(ctx context.Context, _ sync.Locker) error {
 	return c.runHealthCheck(ctx)
 }
 

--- a/internal/mev/blxr/health_test.go
+++ b/internal/mev/blxr/health_test.go
@@ -1,0 +1,27 @@
+package blxr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthProbe(t *testing.T) {
+	expectedBody := `{"id":"1","method":"ping","params":null}`
+	fixture := `{"id":"1","result":{"pong":"2023-08-09 15:29:02.467176"},"jsonrpc":"2.0"}`
+	responder := httpmock.NewStringResponder(200, fixture)
+	httpmock.RegisterMatcherResponder("POST", cBloXRouteCloudAPIURL, httpmock.BodyContainsString(expectedBody), responder)
+	authHeather := "0xDEADBEEF"
+
+	c := New(authHeather)
+	httpmock.ActivateNonDefault(c.rs.GetClient())
+
+	err := c.runHealthCheck(context.Background())
+	require.NoError(t, err)
+
+	count := httpmock.GetTotalCallCount()
+
+	require.Equal(t, 1, count)
+}

--- a/internal/mev/client.go
+++ b/internal/mev/client.go
@@ -1,0 +1,37 @@
+package mev
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/palomachain/pigeon/config"
+	"github.com/palomachain/pigeon/internal/mev/blxr"
+	log "github.com/sirupsen/logrus"
+)
+
+type Client interface {
+	IsHealthy() bool
+	IsChainRegistered(string) bool
+	GetHealthprobeInterval() time.Duration
+	KeepAlive(context.Context, sync.Locker) error
+	RegisterChain(string)
+}
+
+func New(cfg *config.Root) Client {
+	if len(cfg.BloxrouteAuthorizationHeader) < 1 {
+		log.Info("BLXR Auth header not found. No MEV relayer support.")
+		return nil
+	}
+
+	// At the moment, only BLXR is supported
+	c := blxr.New(cfg.BloxrouteAuthorizationHeader)
+	for k, v := range cfg.EVM {
+		if v.EVMSpecificClientConfig.BloxrouteIntegrationEnabled {
+			log.Infof("Adding BLXR relayer support for chain %s", k)
+			c.RegisterChain(k)
+		}
+	}
+
+	return c
+}

--- a/internal/traits/traits.go
+++ b/internal/traits/traits.go
@@ -1,0 +1,23 @@
+package traits
+
+import (
+	valsettypes "github.com/palomachain/paloma/x/valset/types"
+)
+
+type Traits []string
+
+type MevRelayerQuery interface {
+	IsHealthy() bool
+	IsChainRegistered(string) bool
+}
+
+func Build(chainID string, mevClient MevRelayerQuery) Traits {
+	traits := []string{}
+
+	if mevClient == nil || !mevClient.IsHealthy() || !mevClient.IsChainRegistered(chainID) {
+		return traits
+	}
+
+	traits = append(traits, valsettypes.PIGEON_TRAIT_MEV)
+	return traits
+}

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/palomachain/pigeon/chain"
 	"github.com/palomachain/pigeon/chain/paloma"
 	"github.com/palomachain/pigeon/config"
+	"github.com/palomachain/pigeon/internal/mev"
 	utiltime "github.com/palomachain/pigeon/util/time"
 )
 
@@ -61,6 +62,7 @@ type Relayer struct {
 	palomaClient PalomaClienter
 
 	evmFactory EvmFactorier
+	mevClient  mev.Client
 
 	relayerConfig Config
 
@@ -92,4 +94,8 @@ func New(config config.Root, palomaClient PalomaClienter, evmFactory EvmFactorie
 
 func (r *Relayer) SetAppVersion(appVersion string) {
 	r.appVersion = appVersion
+}
+
+func (r *Relayer) SetMevClient(c mev.Client) {
+	r.mevClient = c
 }

--- a/relayer/start.go
+++ b/relayer/start.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/palomachain/paloma/util/libvalid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -68,6 +69,10 @@ func (r *Relayer) Start(ctx context.Context) error {
 	go r.startProcess(ctx, &locker, signMessagesLoopInterval, true, r.SignMessages)
 	go r.startProcess(ctx, &locker, relayMessagesLoopInterval, true, r.RelayMessages)
 	go r.startProcess(ctx, &locker, attestMessagesLoopInterval, true, r.AttestMessages)
+
+	if !libvalid.IsNil(r.mevClient) {
+		go r.startProcess(ctx, &locker, r.mevClient.GetHealthprobeInterval(), false, r.mevClient.KeepAlive)
+	}
 
 	// Start the foreground process
 	r.startProcess(ctx, &locker, r.relayerConfig.KeepAliveLoopTimeout, false, r.keepAlive)

--- a/relayer/update_valset.go
+++ b/relayer/update_valset.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/palomachain/pigeon/chain"
 	"github.com/palomachain/pigeon/chain/paloma"
+	"github.com/palomachain/pigeon/internal/traits"
 	"github.com/palomachain/pigeon/util/slice"
 	log "github.com/sirupsen/logrus"
 )
@@ -27,17 +28,21 @@ func (r *Relayer) UpdateExternalChainInfos(ctx context.Context, locker sync.Lock
 			return p.ExternalAccount()
 		},
 	)
+
 	chainInfos := slice.Map(externalAccounts, func(acc chain.ExternalAccount) paloma.ChainInfoIn {
+		traits := traits.Build(acc.ChainReferenceID, r.mevClient)
 		info := paloma.ChainInfoIn{
 			ChainReferenceID: acc.ChainReferenceID,
 			AccAddress:       acc.Address,
 			ChainType:        acc.ChainType,
 			PubKey:           acc.PubKey,
+			Traits:           traits,
 		}
 		log.WithFields(log.Fields{
 			"chain-reference-id": acc.ChainReferenceID,
 			"acc-address":        acc.Address,
 			"chain-type":         acc.ChainType,
+			"chain-traits":       traits,
 		}).Info("sending account info to paloma")
 		return info
 	})


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/619

# Background

This change introduces a few new additions, namely:

- Pigeon traits: an arbitrary set of capabilities for EVM chains which may be listed per chain and will be stored as part of the active valset on chain
- MEV relaying: scaffolding the possibility to relay messages via MEV endpoints if properly setup in the configuration
- BLXR client: the first (and currently only) implementation of MEV relaying. It's still missing the relay implementation, but everything else is there

The change also includes some housekeeping and directory changes. I was hoping to move towards `pkg/internal` and `pkg/app`, but we won't be able to properly import while other packages remain on the root level, so this will have to do for now.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
