### PR TITLE
Speed up pigeons where useful

### DIFF
--- a/relayer/start.go
+++ b/relayer/start.go
@@ -11,9 +11,9 @@ import (
 
 const (
 	updateExternalChainsLoopInterval = 1 * time.Minute
-	signMessagesLoopInterval         = 1 * time.Second
-	relayMessagesLoopInterval        = 1 * time.Second
-	attestMessagesLoopInterval       = 1 * time.Second
+	signMessagesLoopInterval         = 500 * time.Millisecond
+	relayMessagesLoopInterval        = 500 * time.Millisecond
+	attestMessagesLoopInterval       = 500 * time.Millisecond
 	checkStakingLoopInterval         = 5 * time.Second
 )
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/640

# Background

Paloma's block time is decreasing significantly.  It now makes sense to run pigeon signing, relaying, and attesting at sub-second intervals.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
