### PR TITLE
feat: #745 add health server address binding config

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	_relayer    *relayer.Relayer
-	_config     *config.Root
+	_config     *config.Config
 	_configPath string
 
 	_palomaClient *paloma.Client
@@ -61,7 +61,7 @@ func Commit() string { return commit }
 func Relayer() *relayer.Relayer {
 	if _relayer == nil {
 		_relayer = relayer.New(
-			*Config(),
+			Config(),
 			*PalomaClient(),
 			EvmFactory(),
 			Time(),
@@ -98,7 +98,7 @@ func EvmFactory() *evm.Factory {
 	return _evmFactory
 }
 
-func Config() *config.Root {
+func Config() *config.Config {
 	if len(_configPath) == 0 {
 		log.Fatal("config file path is not set")
 	}
@@ -116,7 +116,7 @@ func Config() *config.Root {
 				"err": err,
 			}).Fatal("couldn't read config file")
 		}
-		_config = &cnf
+		_config = cnf
 	}
 
 	return _config

--- a/cmd/pigeon/cmd_start.go
+++ b/cmd/pigeon/cmd_start.go
@@ -35,7 +35,8 @@ var startCmd = &cobra.Command{
 		go func() {
 			health.StartHTTPServer(
 				ctx,
-				app.Config().HealthCheckPort(),
+				app.Config().HealthCheckAddress,
+				app.Config().HealthCheckPort,
 				pid,
 				app.Version(),
 				app.Commit(),

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,5 @@
 loop-timeout: 5s
+health-check-address: 127.0.0.1
 health-check-port: 5757
 
 paloma:

--- a/health/server.go
+++ b/health/server.go
@@ -20,6 +20,7 @@ type jsonResponse struct {
 
 func StartHTTPServer(
 	ctx context.Context,
+	addr string,
 	port int,
 	pid int,
 	appVersion string,
@@ -38,7 +39,7 @@ func StartHTTPServer(
 	})
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
+		Addr:    fmt.Sprintf("%s:%d", addr, port),
 		Handler: m,
 		BaseContext: func(_ net.Listener) context.Context {
 			return ctx

--- a/internal/mev/client.go
+++ b/internal/mev/client.go
@@ -22,7 +22,7 @@ type Client interface {
 	Relay(context.Context, *big.Int, *types.Transaction) (common.Hash, error)
 }
 
-func New(cfg *config.Root) Client {
+func New(cfg *config.Config) Client {
 	if len(cfg.BloxrouteAuthorizationHeader) < 1 {
 		log.Info("BLXR Auth header not found. No MEV relayer support.")
 		return nil

--- a/relayer/build_processors.go
+++ b/relayer/build_processors.go
@@ -80,7 +80,7 @@ func (r *Relayer) processorFactory(chainInfo *evmtypes.ChainInfo) (chain.Process
 	// TODO: add support of other types of chains! Right now, only EVM types are supported!
 	retErr := whoops.Wrap(ErrMissingChainConfig, whoops.Errorf("reference chain id: %s").Format(chainInfo.GetChainReferenceID()))
 
-	cfg, ok := r.config.EVM[chainInfo.GetChainReferenceID()]
+	cfg, ok := r.cfg.EVM[chainInfo.GetChainReferenceID()]
 	if !ok {
 		return nil, retErr
 	}

--- a/relayer/build_processors_test.go
+++ b/relayer/build_processors_test.go
@@ -48,7 +48,7 @@ func TestBuildProcessors(t *testing.T) {
 				evmFactoryMock.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(processorMock, nil)
 
 				r := New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"chain-1": {},
 						},
@@ -98,7 +98,7 @@ func TestBuildProcessors(t *testing.T) {
 				evmFactoryMock.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(processorMock, nil)
 
 				r := New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"chain-1": {},
 						},
@@ -154,7 +154,7 @@ func TestBuildProcessors(t *testing.T) {
 				evmFactoryMock.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(processorMock, nil)
 
 				r := New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"chain-1": {},
 						},
@@ -215,7 +215,7 @@ func TestBuildProcessors(t *testing.T) {
 				evmFactoryMock.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(processorMock, nil)
 
 				r := New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"chain-1": {},
 						},
@@ -264,7 +264,7 @@ func TestBuildProcessors(t *testing.T) {
 				)
 
 				r := New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"chain-1": {},
 						},

--- a/relayer/health_check.go
+++ b/relayer/health_check.go
@@ -76,7 +76,7 @@ func (r *Relayer) HealthCheck(ctx context.Context) error {
 
 func (r *Relayer) BootHealthCheck(ctx context.Context) error {
 	var g whoops.Group
-	for _, cfg := range r.config.EVM {
+	for _, cfg := range r.cfg.EVM {
 		g.Add(evm.TestAndVerifyConfig(ctx, cfg))
 	}
 	return g.Return()

--- a/relayer/health_check_test.go
+++ b/relayer/health_check_test.go
@@ -30,7 +30,7 @@ var _ = Describe("health check", func() {
 
 	retErr := whoops.String("oh no")
 
-	var cfg config.Root
+	cfg := &config.Config{}
 
 	var val *stakingtypes.Validator
 	BeforeEach(func() {
@@ -50,7 +50,7 @@ var _ = Describe("health check", func() {
 	JustBeforeEach(func() {
 		r = &Relayer{
 			palomaClient: m,
-			config:       cfg,
+			cfg:          cfg,
 			evmFactory:   fm,
 		}
 	})

--- a/relayer/message_attester_test.go
+++ b/relayer/message_attester_test.go
@@ -34,7 +34,7 @@ func TestAttestMessages(t *testing.T) {
 				pc := mocks.NewPalomaClienter(t)
 				pc.On("QueryGetEVMChainInfos", mock.Anything, mock.Anything).Return(nil, nil)
 				r := New(
-					config.Root{},
+					&config.Config{},
 					pc,
 					evm.NewFactory(evmmocks.NewPalomaClienter(t)),
 					timemocks.NewTime(t),
@@ -95,7 +95,7 @@ func TestAttestMessages(t *testing.T) {
 				factory.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(p, nil)
 
 				return New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"main": {
 								ChainClientConfig: config.ChainClientConfig{
@@ -144,7 +144,7 @@ func TestAttestMessages(t *testing.T) {
 				factory.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(p, nil)
 
 				return New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"main": {
 								ChainClientConfig: config.ChainClientConfig{

--- a/relayer/message_relayer_test.go
+++ b/relayer/message_relayer_test.go
@@ -34,7 +34,7 @@ func TestRelayMessages(t *testing.T) {
 				pc := mocks.NewPalomaClienter(t)
 				pc.On("QueryGetEVMChainInfos", mock.Anything, mock.Anything).Return(nil, nil)
 				r := New(
-					config.Root{},
+					&config.Config{},
 					pc,
 					evm.NewFactory(evmmocks.NewPalomaClienter(t)),
 					timemocks.NewTime(t),
@@ -98,7 +98,7 @@ func TestRelayMessages(t *testing.T) {
 				factory.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(p, nil)
 
 				return New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"main": {
 								ChainClientConfig: config.ChainClientConfig{
@@ -147,7 +147,7 @@ func TestRelayMessages(t *testing.T) {
 				factory.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(p, nil)
 
 				return New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"main": {
 								ChainClientConfig: config.ChainClientConfig{

--- a/relayer/message_signer_test.go
+++ b/relayer/message_signer_test.go
@@ -33,7 +33,7 @@ func TestSignMessages(t *testing.T) {
 				pc := mocks.NewPalomaClienter(t)
 				pc.On("QueryGetEVMChainInfos", mock.Anything, mock.Anything).Return(nil, nil)
 				return New(
-					config.Root{},
+					&config.Config{},
 					pc,
 					evm.NewFactory(evmmocks.NewPalomaClienter(t)),
 					timemocks.NewTime(t),
@@ -89,7 +89,7 @@ func TestSignMessages(t *testing.T) {
 				factory.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(p, nil)
 
 				return New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"main": {
 								ChainClientConfig: config.ChainClientConfig{
@@ -138,7 +138,7 @@ func TestSignMessages(t *testing.T) {
 				factory.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(p, nil)
 
 				return New(
-					config.Root{
+					&config.Config{
 						EVM: map[string]config.EVM{
 							"main": {
 								ChainClientConfig: config.ChainClientConfig{

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -63,7 +63,7 @@ type EvmFactorier interface {
 }
 
 type Relayer struct {
-	config config.Root
+	cfg *config.Config
 
 	palomaClient PalomaClienter
 
@@ -87,9 +87,9 @@ type Config struct {
 	KeepAliveBlockThreshold int64
 }
 
-func New(config config.Root, palomaClient PalomaClienter, evmFactory EvmFactorier, customTime utiltime.Time, cfg Config) *Relayer {
+func New(config *config.Config, palomaClient PalomaClienter, evmFactory EvmFactorier, customTime utiltime.Time, cfg Config) *Relayer {
 	return &Relayer{
-		config:        config,
+		cfg:           config,
 		palomaClient:  palomaClient,
 		evmFactory:    evmFactory,
 		time:          customTime,


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/745

# Background

This change adds a new configuration field for server health server address binding. It also contains some minor housekeeping chores.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
