### PR TITLE
Force keep-alive cache invalidation

### DIFF
--- a/relayer/heartbeat/cache.go
+++ b/relayer/heartbeat/cache.go
@@ -24,6 +24,7 @@ type keepAliveCache struct {
 	lastAliveUntil      int64
 	queryBTL            AliveUntilHeightQuery
 	queryBH             CurrentHeightQuery
+	invalidated         bool
 }
 
 func (c *keepAliveCache) get(ctx context.Context) (int64, error) {
@@ -50,20 +51,23 @@ func (c *keepAliveCache) get(ctx context.Context) (int64, error) {
 	return c.lastAliveUntil, nil
 }
 
+func (c *keepAliveCache) invalidate() {
+	c.invalidated = true
+}
+
 func (c *keepAliveCache) refresh(ctx context.Context, locker sync.Locker) error {
 	defer locker.Unlock()
 	logger := liblog.WithContext(ctx).WithField("component", "cache")
 	logger.Debug("refreshing cache")
 
 	locker.Lock()
-	logger.Debug("Lock aquired. query btl.")
+	logger.Debug("Lock aquired.")
 	abh, err := c.queryBTL(ctx)
 	if err != nil {
 		logger.WithError(err).Error("failed to query alive until height")
 		return err
 	}
 
-	logger.Debug("query bh.")
 	bh, err := c.queryBH(ctx)
 	if err != nil {
 		logger.WithError(err).Error("failed to query current height")
@@ -74,13 +78,17 @@ func (c *keepAliveCache) refresh(ctx context.Context, locker sync.Locker) error 
 	c.lastAliveUntil = abh
 	c.lastBlockHeight = bh
 	c.lastRefresh = time.Now().UTC()
+	c.invalidated = false
 
 	logger.Debug("done refreshing cache")
 	return nil
 }
 
 func (c *keepAliveCache) isStale() bool {
-	if c.estimatedBlockSpeed == 0 || c.lastBlockHeight == 0 || c.lastRefresh.IsZero() {
+	if c.invalidated ||
+		c.estimatedBlockSpeed == 0 ||
+		c.lastBlockHeight == 0 ||
+		c.lastRefresh.IsZero() {
 		return true
 	}
 

--- a/relayer/heartbeat/cache.go
+++ b/relayer/heartbeat/cache.go
@@ -56,12 +56,14 @@ func (c *keepAliveCache) refresh(ctx context.Context, locker sync.Locker) error 
 	logger.Debug("refreshing cache")
 
 	locker.Lock()
+	logger.Debug("Lock aquired. query btl.")
 	abh, err := c.queryBTL(ctx)
 	if err != nil {
 		logger.WithError(err).Error("failed to query alive until height")
 		return err
 	}
 
+	logger.Debug("query bh.")
 	bh, err := c.queryBH(ctx)
 	if err != nil {
 		logger.WithError(err).Error("failed to query current height")
@@ -73,6 +75,7 @@ func (c *keepAliveCache) refresh(ctx context.Context, locker sync.Locker) error 
 	c.lastBlockHeight = bh
 	c.lastRefresh = time.Now().UTC()
 
+	logger.Debug("done refreshing cache")
 	return nil
 }
 

--- a/relayer/heartbeat/cache.go
+++ b/relayer/heartbeat/cache.go
@@ -61,7 +61,7 @@ func (c *keepAliveCache) refresh(ctx context.Context, locker sync.Locker) error 
 	logger.Debug("refreshing cache")
 
 	locker.Lock()
-	logger.Debug("Lock aquired.")
+	logger.Debug("Lock acquired.")
 	abh, err := c.queryBTL(ctx)
 	if err != nil {
 		logger.WithError(err).Error("failed to query alive until height")

--- a/relayer/heartbeat/cache_test.go
+++ b/relayer/heartbeat/cache_test.go
@@ -105,6 +105,16 @@ func TestCache(t *testing.T) {
 	})
 
 	t.Run("isStale", func(t *testing.T) {
+		t.Run("with missing invalidated flag set", func(t *testing.T) {
+			c := &keepAliveCache{
+				lastBlockHeight:     10,
+				lastRefresh:         tm,
+				estimatedBlockSpeed: time.Second,
+			}
+			c.invalidate()
+			require.True(t, c.isStale(), "must return true")
+		})
+
 		t.Run("with missing estimated block speed", func(t *testing.T) {
 			c := &keepAliveCache{
 				lastBlockHeight: 10,

--- a/relayer/heartbeat/heartbeat.go
+++ b/relayer/heartbeat/heartbeat.go
@@ -87,6 +87,8 @@ func (m *Heart) trySendKeepAlive(ctx context.Context, locker sync.Locker) (err e
 	err = m.sendKeepAlive(ctx, m.appVersion)
 	locker.Unlock()
 	if err == nil {
+		// Make sure we flag the cache for refreshing now
+		m.c.invalidate()
 		return nil
 	}
 

--- a/relayer/heartbeat/heartbeat.go
+++ b/relayer/heartbeat/heartbeat.go
@@ -46,7 +46,8 @@ func New(i AliveUntilHeightQuery, j CurrentHeightQuery, k KeepAliveCall, keepAli
 }
 
 func (m *Heart) Beat(ctx context.Context, locker sync.Locker) error {
-	logger := liblog.WithContext(ctx)
+	logger := liblog.WithContext(ctx).WithField("component", "Heart.Beat")
+	logger.Debug("Running heartbeat")
 
 	aliveUntil, err := m.c.get(ctx)
 	if err != nil {


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/973

# Background

This introduces some additional logging around sending keep alive calls. The most important change is the forced cache invalidation after a successful keep-alive call to Paloma in order to avoid unneeded calls.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
