### PR TITLE
Slow down evm event checking

### DIFF
--- a/relayer/start.go
+++ b/relayer/start.go
@@ -18,11 +18,10 @@ const (
 	attestMessagesLoopInterval       = 500 * time.Millisecond
 	checkStakingLoopInterval         = 5 * time.Second
 
-	updateGravityOrchestratorAddressInterval = 1 * time.Minute
-	gravitySignBatchesLoopInterval           = 5 * time.Second
-	gravityRelayBatchesLoopInterval          = 5 * time.Second
-	batchSendEventWatcherLoopInterval        = 5 * time.Second
-	sendToPalomaEventWatcherLoopInterval     = 5 * time.Second
+	gravitySignBatchesLoopInterval       = 5 * time.Second
+	gravityRelayBatchesLoopInterval      = 5 * time.Second
+	batchSendEventWatcherLoopInterval    = 5 * time.Second
+	sendToPalomaEventWatcherLoopInterval = 1 * time.Minute
 )
 
 func (r *Relayer) checkStaking(ctx context.Context, locker sync.Locker) error {


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/976

# Background

This was previously checking every 5 seconds for events to send a token to Paloma.  This may be unnecessarily using up RPC calls for pigeons when not much is happening.  Slowing this down, which will effectively reduce the call numbers while batching events that may happen together.

Also removed an unused interval accidentally left in

# Testing completed

- [x] this is a loop interval, no tests exist or are needed for it
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
