### PR TITLE
feat: prevent unrealistic estimates during chain halt

### DIFF
--- a/relayer/heartbeat/cache_test.go
+++ b/relayer/heartbeat/cache_test.go
@@ -93,6 +93,24 @@ func TestCache(t *testing.T) {
 			require.Equal(t, cDefaultBlockSpeed, i, "must return default block speed")
 		})
 
+		t.Run("with unrealistically low block height difference", func(t *testing.T) {
+			c := &keepAliveCache{
+				lastBlockHeight: 10,
+				lastRefresh:     tm.Add(time.Minute * -1),
+			}
+			i := c.estimateBlockSpeed(29, tm)
+			require.Equal(t, cDefaultBlockSpeed, i, "must return default block speed")
+		})
+
+		t.Run("with unrealistically high time difference", func(t *testing.T) {
+			c := &keepAliveCache{
+				lastBlockHeight: 10,
+				lastRefresh:     tm.Add(time.Hour * -1),
+			}
+			i := c.estimateBlockSpeed(60, tm)
+			require.Equal(t, cDefaultBlockSpeed, i, "must return default block speed")
+		})
+
 		t.Run("with valid parameters", func(t *testing.T) {
 			c := &keepAliveCache{
 				lastBlockHeight: 10,


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/794

# Background

We check every 30 blocks, not seconds. How does Pigeon know when 30 blocks are due? By estimating the block speed. How does it know the block speed? By comparing block heights when refreshing its cache. So if we get a very low height difference of blocks right after a halt, Pigeons won't be calling in for a good while, as they think the chain is moving very slowly now (which it isn't).

This change adds some thresholds to both, the last cache refresh time delta, and the last block height delta. In case either of them is hit, we simply work with the default values.

Side effect: eventually, this will also trigger Pigeons to keep aggressively unjailing during a chain halt, so once we start moving again, their TTL will be refreshed.


# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
