### PR TITLE
fix: avoid race condition when building chain processors

### DIFF
--- a/chain/evm/processor.go
+++ b/chain/evm/processor.go
@@ -65,10 +65,6 @@ func (p Processor) SignMessages(ctx context.Context, messages ...chain.QueuedMes
 			"message-id": msg.ID,
 		}).Info("signed a message")
 
-		if err != nil {
-			return chain.SignedQueuedMessage{}, err
-		}
-
 		return chain.SignedQueuedMessage{
 			QueuedMessage:   msg,
 			Signature:       sig,

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -3,6 +3,7 @@ package relayer
 import (
 	"context"
 	"math/big"
+	"sync"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -74,8 +75,9 @@ type Relayer struct {
 
 	time utiltime.Time
 
-	chainsInfos []evmtypes.ChainInfo
-	processors  []chain.Processor
+	chainsInfos      []evmtypes.ChainInfo
+	processors       []chain.Processor
+	procRefreshMutex *sync.RWMutex
 
 	staking bool
 
@@ -89,12 +91,13 @@ type Config struct {
 
 func New(config *config.Config, palomaClient PalomaClienter, evmFactory EvmFactorier, customTime utiltime.Time, cfg Config) *Relayer {
 	return &Relayer{
-		cfg:           config,
-		palomaClient:  palomaClient,
-		evmFactory:    evmFactory,
-		time:          customTime,
-		relayerConfig: cfg,
-		staking:       false,
+		cfg:              config,
+		palomaClient:     palomaClient,
+		evmFactory:       evmFactory,
+		time:             customTime,
+		relayerConfig:    cfg,
+		staking:          false,
+		procRefreshMutex: &sync.RWMutex{},
 	}
 }
 

--- a/relayer/update_valset.go
+++ b/relayer/update_valset.go
@@ -6,55 +6,50 @@ import (
 
 	"github.com/palomachain/pigeon/chain"
 	"github.com/palomachain/pigeon/chain/paloma"
+	"github.com/palomachain/pigeon/internal/liblog"
 	"github.com/palomachain/pigeon/internal/traits"
-	"github.com/palomachain/pigeon/util/slice"
 	log "github.com/sirupsen/logrus"
 )
 
 func (r *Relayer) UpdateExternalChainInfos(ctx context.Context, locker sync.Locker) error {
-	err := r.buildProcessors(ctx, locker)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"err": err,
-		}).Error("couldn't build processors to update external chain info")
+	logger := liblog.WithContext(ctx).WithField("component", "update-external-chain-infos")
+	logger.Info("updating external chain infos")
 
+	if err := r.buildProcessors(ctx, locker); err != nil {
+		logger.WithError(err).Error("couldn't build processors to update external chain info")
 		return err
 	}
 
-	log.Info("updating external chain infos")
-	externalAccounts := slice.Map(
-		r.processors,
-		func(p chain.Processor) chain.ExternalAccount {
-			return p.ExternalAccount()
-		},
-	)
+	externalAccounts := make([]chain.ExternalAccount, len(r.processors))
+	for i, v := range r.processors {
+		externalAccounts[i] = v.ExternalAccount()
+	}
 
-	// log.Info("Updating erc20 coin contract for chain")
-
-	chainInfos := slice.Map(externalAccounts, func(acc chain.ExternalAccount) paloma.ChainInfoIn {
-		traits := traits.Build(acc.ChainReferenceID, r.mevClient)
-		info := paloma.ChainInfoIn{
-			ChainReferenceID: acc.ChainReferenceID,
-			AccAddress:       acc.Address,
-			ChainType:        acc.ChainType,
-			PubKey:           acc.PubKey,
-			Traits:           traits,
-		}
-		log.WithFields(log.Fields{
-			"chain-reference-id": acc.ChainReferenceID,
-			"acc-address":        acc.Address,
-			"chain-type":         acc.ChainType,
+	chainInfos := make([]paloma.ChainInfoIn, len(externalAccounts))
+	for i, v := range externalAccounts {
+		traits := traits.Build(v.ChainReferenceID, r.mevClient)
+		logger.WithFields(log.Fields{
+			"chain-reference-id": v.ChainReferenceID,
+			"acc-address":        v.Address,
+			"chain-type":         v.ChainType,
 			"chain-traits":       traits,
 		}).Info("sending account info to paloma")
-		return info
-	})
 
-	if len(chainInfos) == 0 {
+		chainInfos[i] = paloma.ChainInfoIn{
+			ChainReferenceID: v.ChainReferenceID,
+			AccAddress:       v.Address,
+			ChainType:        v.ChainType,
+			PubKey:           v.PubKey,
+			Traits:           traits,
+		}
+	}
+
+	if len(chainInfos) < 1 {
 		return nil
 	}
 
 	locker.Lock()
-	err = r.palomaClient.AddExternalChainInfo(ctx, chainInfos...)
+	err := r.palomaClient.AddExternalChainInfo(ctx, chainInfos...)
 	locker.Unlock()
 
 	return err


### PR DESCRIPTION
# Background

I'm surprised this hasn't flared up before. Pigeons will usually "build processors" before every operation, meaning they will ask Paloma for the latest chain configuration and compare their local setup. In case there's a difference, they will rebuild their local setup to match what's asked for by Paloma. 

The code for this was not written with concurrency in mind, but is part of most of our background tasks which all run concurrently. Therefore, updating the internal state would interfere with each other, leading to contradicting results, a ton of update calls, invalid and incomplete data in the valsets and more.

This change adds a read/write mutual exclusion lock around the code in question, ensuring that reads stay performant, but don't interfere with updating the internal state any longer.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
