### PR TITLE
fix: remove keep alive mutex locking

### DIFF
--- a/relayer/start.go
+++ b/relayer/start.go
@@ -57,6 +57,8 @@ func (r *Relayer) startProcess(ctx context.Context, name string, locker sync.Loc
 				err := process(jCtx, locker)
 				if err != nil {
 					liblog.WithContext(jCtx).WithField("component", "procmon").WithField("process", name).WithError(err).Errorf("Failed to execute process: %v", err)
+				} else {
+					liblog.WithContext(jCtx).WithField("component", "procmon").WithField("process", name).Debug("Process executed")
 				}
 			} else {
 				logger.Debug("validor not staking, skipping process execution...")


### PR DESCRIPTION
I thought I had done this one earlier, but it seems the changes from my branch never went on to master. This will help with the jailing of pigeons who starve while waiting for the lock, but it will increase the amount of `incorrect account sequence` errors we'll see. This should be addressed with operator keys sooner rather than later.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
