### PR TITLE
fix: avoid retries on already executed messages

### DIFF
--- a/chain/evm/compass_test.go
+++ b/chain/evm/compass_test.go
@@ -259,7 +259,7 @@ func TestMessageProcessing(t *testing.T) {
 		expErr error
 	}{
 		{
-			name: "submit_logic_call/message is already executed then it does nothing",
+			name: "submit_logic_call/message is already executed then it returns an error",
 			msgs: []chain.MessageWithSignatures{
 				{
 					QueuedMessage: chain.QueuedMessage{
@@ -281,6 +281,7 @@ func TestMessageProcessing(t *testing.T) {
 					},
 				}
 
+				paloma.On("AddStatusUpdate", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				evm.On("FilterLogs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Times(1).Return(false, nil).Run(func(args mock.Arguments) {
 					fn := args.Get(3).(func([]etherumtypes.Log) bool)
 					fn(isArbitraryCallExecutedLogs)
@@ -293,6 +294,7 @@ func TestMessageProcessing(t *testing.T) {
 
 				return evm, paloma
 			},
+			expErr: ErrCallAlreadyExecuted,
 		},
 		{
 			name: "submit_logic_call/happy path",

--- a/chain/evm/errors.go
+++ b/chain/evm/errors.go
@@ -13,7 +13,8 @@ const (
 
 	ErrEvm = whoops.String("EVM related error")
 
-	ErrNoConsensus = whoops.String("no consensus reached")
+	ErrNoConsensus         = whoops.String("no consensus reached")
+	ErrCallAlreadyExecuted = whoops.String("message with identical ID already on target chain")
 
 	ErrCouldntFindBlockWithTime = whoops.String("couldn't find block")
 )

--- a/cmd/pigeon/cmd_evm.go
+++ b/cmd/pigeon/cmd_evm.go
@@ -255,7 +255,7 @@ var (
 			countOK, total := 0, 0
 			for _, msg := range msgs {
 				logger = logger.WithField("msg-id", msg.ID)
-				xconsensus := evm.BuildCompassConsensus(ctx, valset, msg.Signatures)
+				xconsensus := evm.BuildCompassConsensus(valset, msg.Signatures)
 				logger.Info("message has ", len(msg.Signatures), " signatures")
 				logger.Info("there are ", len(xconsensus.Valset.Validators), " validators in the valset validator consensus")
 				for i := range xconsensus.Valset.Validators {


### PR DESCRIPTION
This change primarily targets the `SubmitLogicCall` handler, returning an error in case a message matching the current message ID is already found on the target chain. This error will now be added to the `error data` of the message, instructing Paloma to clear it from the queue. It might still be retried once with a different pigeon, but not clog the queue for 45 minutes.