### PR TITLE
fix: filter gravity batches queried from paloma

### DIFF
--- a/chain/paloma/client.go
+++ b/chain/paloma/client.go
@@ -480,7 +480,14 @@ func gravityQueryLastUnsignedBatch(ctx context.Context, grpcClient grpc.ClientCo
 		return nil, err
 	}
 
-	return batches.Batch, nil
+	filtered := make([]gravity.OutgoingTxBatch, 0, len(batches.Batch))
+	for _, v := range batches.Batch {
+		if v.GetChainReferenceID() == chainReferenceID {
+			filtered = append(filtered, v)
+		}
+	}
+
+	return filtered, nil
 }
 
 func (c Client) GravityConfirmBatches(ctx context.Context, signatures ...chain.SignedGravityOutgoingTxBatch) error {


### PR DESCRIPTION
This change adds some filtering when querying messages from Paloma, which by default will not be filtered by chain ID.

I don't know why this wasn't part of the original change that added the gravity stuff, I imagine it was simply overlooked. I tried to add some test coverage as well, but I find the current solution to be more than lacking. We define the protobuf stuff in Paloma, then we also generate the mocks there. There's no automation or `go:generate` for this, and most packages don't even include mocks for the protobuf parts.

So, even going ahead manually creating the mocks in Paloma, pushing the changes, updating the references in Pigeon and writing a test against it, there is 0 guarantee that a future dev (or me) will make changes to the proto definitions and simply not update the mocks. 

If anything, the mocks should be created in Pigeon itself. It's something we should look at in the future. It also feeds into the protobuf definitions, which should probably rest in their own repository if we opt out of the monorepo approach.