### PR TITLE
chore: re-introduce locking

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -67,7 +67,7 @@ func Relayer() *relayer.Relayer {
 			Time(),
 			relayer.Config{
 				KeepAliveLoopTimeout:    5 * gotime.Second,
-				KeepAliveBlockThreshold: 30,
+				KeepAliveBlockThreshold: 600, // Approximately 15 minutes at 1.62 blocks per second
 			},
 		)
 	}

--- a/relayer/heartbeat/heartbeat.go
+++ b/relayer/heartbeat/heartbeat.go
@@ -80,10 +80,15 @@ func (m *Heart) SetRetryFalloff(falloff time.Duration) {
 }
 
 // Will be blocking during retries. Make sure to always call in Goroutine.
-func (m *Heart) trySendKeepAlive(ctx context.Context, _ sync.Locker) (err error) {
-	logger := liblog.WithContext(ctx)
+func (m *Heart) trySendKeepAlive(ctx context.Context, locker sync.Locker) (err error) {
+	logger := liblog.WithContext(ctx).WithField("component", "try-send-keep-alive")
 
+	logger.Debug("Trying to acquire lock.")
+	locker.Lock()
+	logger.Debug("Lock acquired.")
 	err = m.sendKeepAlive(ctx, m.appVersion)
+	logger.Debug("Freeing lock.")
+	locker.Unlock()
 	if err != nil {
 		logger.WithError(err).Error("Error while trying to keep pigeon alive.")
 		return err


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/856

# Background

This brings back locking when making calls to keep alive. In order to prevent a jailing due to sometimes very long waiting times to acquire the lock (> 1 minute), we start calling 15 minutes before the new TTL (approx 1 hr) runs out.

# Testing completed

- [x] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
