### PR TITLE
Prework: gravity compass upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This repo does not accept issues. Please use https://github.com/palomachain/palo
 ### To get the latest prebuilt `pigeon` binary:
 
 ```shell
-wget -O - https://github.com/palomachain/pigeon/releases/download/v1.9.0/pigeon_Linux_x86_64.tar.gz  | \
+wget -O - https://github.com/palomachain/pigeon/releases/download/v1.9.2/pigeon_Linux_x86_64.tar.gz  | \
   sudo tar -C /usr/local/bin -xvzf - pigeon
 sudo chmod +x /usr/local/bin/pigeon
 
@@ -69,7 +69,7 @@ mkdir ~/.pigeon
 ```shell
 git clone https://github.com/palomachain/pigeon.git
 cd pigeon
-git checkout v1.9.0
+git checkout v1.9.2
 make build
 sudo mv ./build/pigeon /usr/local/bin/pigeon
 

--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -537,7 +537,9 @@ func (t compass) processMessages(ctx context.Context, queueTypeName string, msgs
 				action.UploadSmartContract,
 				rawMsg,
 			)
-			lastTxHashLkup[t.ChainReferenceID] = tx.Hash().Bytes()
+			if tx != nil {
+				lastTxHashLkup[t.ChainReferenceID] = tx.Hash().Bytes()
+			}
 		default:
 			return ErrUnsupportedMessageType.Format(action)
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/onsi/ginkgo/v2 v2.12.1
 	github.com/onsi/gomega v1.28.0
-	github.com/palomachain/paloma v1.8.2
+	github.com/palomachain/paloma v1.9.1
 	github.com/roodeag/arbitrum v0.0.0-20230627104516-b95e4c8ebec0
 	github.com/rs/xid v1.5.0
 	github.com/sirupsen/logrus v1.9.3
@@ -201,9 +201,8 @@ require (
 )
 
 replace (
-	github.com/ethereum/go-ethereum v1.11.6 => github.com/ethereum-optimism/op-geth v1.101106.0-rc.2
 	// Link to op-geth, which is built on top of go-ethereum
-	github.com/palomachain/paloma => github.com/volumefi/paloma v1.5.0-next.0.20231004172440-448a25d361ec
+	github.com/ethereum/go-ethereum v1.11.6 => github.com/ethereum-optimism/op-geth v1.101106.0-rc.2
 	github.com/roodeag/arbitrum => github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936
 	github.com/strangelove-ventures/lens => github.com/volumefi/lens-1 v0.5.5
 )

--- a/go.mod
+++ b/go.mod
@@ -201,8 +201,9 @@ require (
 )
 
 replace (
-	// Link to op-geth, which is built on top of go-ethereum
 	github.com/ethereum/go-ethereum v1.11.6 => github.com/ethereum-optimism/op-geth v1.101106.0-rc.2
+	// Link to op-geth, which is built on top of go-ethereum
+	github.com/palomachain/paloma => github.com/volumefi/paloma v1.5.0-next.0.20231004172440-448a25d361ec
 	github.com/roodeag/arbitrum => github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936
 	github.com/strangelove-ventures/lens => github.com/volumefi/lens-1 v0.5.5
 )

--- a/go.sum
+++ b/go.sum
@@ -881,8 +881,6 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936 h1:fmQAgxcdYBxCZYczws/uxTVOYHZd4fNrOaoHp35HZMM=
 github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936/go.mod h1:B2H2+2I4UiMR4hvAIaGLyYszNfSTYC8fWIw+kgfuFSQ=
-github.com/palomachain/paloma v1.8.2 h1:evHy1tGeKdN49HpwSan/KnN8rf7yBq1e2T9KWkxti1s=
-github.com/palomachain/paloma v1.8.2/go.mod h1:B6MacaQrOeh7183odvy4K+3IAsI50P/B3Wmm4eUjkEI=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1054,6 +1052,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa h1:5SqCsI/2Qya2bCzK15ozrqo2sZxkh0FHynJZOTVoV6Q=
 github.com/volumefi/lens-1 v0.5.5 h1:OmSZOXRn7gsVuQ2ucjoEObIgPRD8D/RYPzcCHgmFclQ=
 github.com/volumefi/lens-1 v0.5.5/go.mod h1:6PdiMJFYkr4Mm3ioZ4UdidpQ1o9lspP0qX31NUsacF4=
+github.com/volumefi/paloma v1.5.0-next.0.20231004172440-448a25d361ec h1:7+4qH8Pmaw2S19icTelKaHr7lGXXX3hd2GCDUDZuZms=
+github.com/volumefi/paloma v1.5.0-next.0.20231004172440-448a25d361ec/go.mod h1:1pfmbrte/u/REwqjB+c1HOZaMbtmOGQbxLNwKSIvFa0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=

--- a/go.sum
+++ b/go.sum
@@ -881,6 +881,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936 h1:fmQAgxcdYBxCZYczws/uxTVOYHZd4fNrOaoHp35HZMM=
 github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936/go.mod h1:B2H2+2I4UiMR4hvAIaGLyYszNfSTYC8fWIw+kgfuFSQ=
+github.com/palomachain/paloma v1.9.1 h1:3A8m5AoYL59uDkbHCvHD9cIEExjASbEwfdZzm5xAw2Y=
+github.com/palomachain/paloma v1.9.1/go.mod h1:1pfmbrte/u/REwqjB+c1HOZaMbtmOGQbxLNwKSIvFa0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1052,8 +1054,6 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa h1:5SqCsI/2Qya2bCzK15ozrqo2sZxkh0FHynJZOTVoV6Q=
 github.com/volumefi/lens-1 v0.5.5 h1:OmSZOXRn7gsVuQ2ucjoEObIgPRD8D/RYPzcCHgmFclQ=
 github.com/volumefi/lens-1 v0.5.5/go.mod h1:6PdiMJFYkr4Mm3ioZ4UdidpQ1o9lspP0qX31NUsacF4=
-github.com/volumefi/paloma v1.5.0-next.0.20231004172440-448a25d361ec h1:7+4qH8Pmaw2S19icTelKaHr7lGXXX3hd2GCDUDZuZms=
-github.com/volumefi/paloma v1.5.0-next.0.20231004172440-448a25d361ec/go.mod h1:1pfmbrte/u/REwqjB+c1HOZaMbtmOGQbxLNwKSIvFa0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/795

# Background

This includes the scaffolding for the full erc20 ownership transfer. We're pushing this out as an intermediate solution to prevent the chain from getting stuck in a deployment loop. The remaining work will be to actually call the old compass, verifying that the TX was executed properly before reporting on the outcome.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
