### PR TITLE
fix: missing message iface registration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	consensustypes "github.com/palomachain/paloma/x/consensus/types"
 	evmtypes "github.com/palomachain/paloma/x/evm/types"
+	palomatypes "github.com/palomachain/paloma/x/paloma/types"
 	valsettypes "github.com/palomachain/paloma/x/valset/types"
 	"github.com/palomachain/pigeon/chain"
 	"github.com/palomachain/pigeon/chain/evm"
@@ -174,6 +175,7 @@ func palomaLensClientConfig(palomaConfig config.Paloma) *lens.ChainClientConfig 
 					&consensustypes.MsgAddEvidence{},
 					&consensustypes.MsgSetPublicAccessData{},
 					&consensustypes.MsgSetErrorData{},
+					&palomatypes.MsgAddStatusUpdate{},
 				},
 			},
 			{
@@ -184,6 +186,7 @@ func palomaLensClientConfig(palomaConfig config.Paloma) *lens.ChainClientConfig 
 					&evmtypes.SmartContractExecutionErrorProof{},
 					&evmtypes.ValidatorBalancesAttestation{},
 					&evmtypes.ValidatorBalancesAttestationRes{},
+					&evmtypes.TransferERC20Ownership{},
 				},
 			},
 		},


### PR DESCRIPTION
To be honest, I'm not 100% sure whether this is still needed, as it seems to work fine without. But other messages are registered here, and according to
https://github.com/strangelove-ventures/lens/issues/300, some codecs might be missing without.

Tested in private test net.