### PR TITLE
fix: don't return an error

### DIFF
--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -197,8 +197,11 @@ func (t compass) submitLogicCall(
 	}
 	if valsetID != expectedValset.Id {
 		err := fmt.Errorf("target chain valset mismatch, expected %d, got %v", expectedValset.Id, valsetID)
-		logger.WithError(err).Error("Target chain valset mismatch!")
-		return nil, err
+		logger.WithError(err).Error("Target chain valset mismatch! Swallowing error so message will be retried...")
+		if err := t.paloma.AddStatusUpdate(ctx, palomatypes.MsgAddStatusUpdate_LEVEL_ERROR, err.Error()); err != nil {
+			logger.WithError(err).Error("Failed to send log to Paloma.")
+		}
+		return nil, nil
 	}
 
 	valset, err := t.paloma.QueryGetEVMValsetByID(ctx, valsetID, t.ChainReferenceID)

--- a/chain/evm/compass_test.go
+++ b/chain/evm/compass_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"errors"
-	"fmt"
 	"math/big"
 	"os"
 	"strings"
@@ -361,7 +360,7 @@ func TestMessageProcessing(t *testing.T) {
 			},
 		},
 		{
-			name: "submit_logic_call/with target chain valset id not matching expected valset id, it should return an error",
+			name: "submit_logic_call/with target chain valset id not matching expected valset id, it should NOT return an error, but report log to Paloma",
 			msgs: []chain.MessageWithSignatures{
 				{
 					QueuedMessage: chain.QueuedMessage{
@@ -404,7 +403,6 @@ func TestMessageProcessing(t *testing.T) {
 				paloma.On("AddStatusUpdate", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				return evm, paloma
 			},
-			expErr: fmt.Errorf("target chain valset mismatch, expected %d, got %v", 56, 55),
 		},
 		{
 			name: "submit_logic_call/happy path with mev relaying",


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/855

# Background

There's actually no reason to return an error in case we have a valset mismatch. We just log the matter and stop processing of the message until the next loop. It's cleaner, more cost efficient and reliable.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
