### PR TITLE
fix: prevent gravity batches being resubmitted indefinitely

### DIFF
--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -380,14 +380,11 @@ func (t compass) isArbitraryCallAlreadyExecuted(ctx context.Context, messageID u
 }
 
 func (t compass) gravityIsBatchAlreadyRelayed(ctx context.Context, batchNonce uint64) (bool, error) {
-	logger := liblog.WithContext(ctx).WithField("component", "gravity-is-batch-already-relayed").WithField("batch-nonce", batchNonce)
-	logger.Debug("querying block number")
 	blockNumber, err := t.evm.FindCurrentBlockNumber(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	logger.WithField("block-number", blockNumber).Debug("got block number")
 	fromBlock := *big.NewInt(0)
 	fromBlock.Sub(blockNumber, big.NewInt(9999))
 	filter := ethereum.FilterQuery{
@@ -402,35 +399,29 @@ func (t compass) gravityIsBatchAlreadyRelayed(ctx context.Context, batchNonce ui
 		FromBlock: &fromBlock,
 	}
 
-	logger.Debug("Filtering logs...")
-	var found bool
-	_, err = t.evm.FilterLogs(ctx, filter, nil, func(logs []ethtypes.Log) bool {
-		logger.Debug(fmt.Sprintf("found %d logs", len(logs)))
-		for i, ethLog := range logs {
-			logger.
-				WithField("log-number", i).
-				WithField("tx-hash", ethLog.TxHash.Hex()).
-				WithField("block-number", ethLog.BlockNumber).
-				Debug("Checking log")
+	found, err := t.evm.FilterLogs(ctx, filter, nil, func(logs []ethtypes.Log) bool {
+		for _, ethLog := range logs {
 			event, err := t.compassAbi.Unpack("BatchSendEvent", ethLog.Data)
 			if err != nil {
-				logger.WithError(err).Debug("failed to unpack event")
-				found = true
+				// Failed to unpack. Let's assume the message has been sent already.
+				liblog.WithContext(ctx).WithField("batch-nonce", batchNonce).WithField("event", event).WithError(err).Error("Failed to unpack log event.")
+				return true
 			}
 
 			logBatchNonce, ok := event[1].(*big.Int)
 			if !ok {
-				logger.Debug("failed to parse log batch nonce")
-				found = true
+				// Failed to parse nonce. Let's assume the message has been sent already.
+				liblog.WithContext(ctx).WithField("batch-nonce", batchNonce).WithField("log-batch-nonce", logBatchNonce).Error("Failed to parse nonce to *big.Int.")
+				return true
 			}
-			logger.WithField("log-batch-nonce", logBatchNonce.Uint64()).Debug("Found nonce")
-			found = batchNonce == logBatchNonce.Uint64()
+
+			if batchNonce == logBatchNonce.Uint64() {
+				return true
+			}
 		}
 
-		logger.WithField("found", found).Debug("Returning...")
-		return found
+		return false
 	})
-
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/880

# Background

Looks like there was a bug in the gravity code that would loop over all log events on the target chain for the past 9999 blocks, but would not exit the loop if it found a match, overriding its results in the process and therefore always failing to notice the already processed message.

# Testing completed

- [x] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
