### PR TITLE
fix: missing interface registrations

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	consensustypes "github.com/palomachain/paloma/x/consensus/types"
 	evmtypes "github.com/palomachain/paloma/x/evm/types"
+	gravitytypes "github.com/palomachain/paloma/x/gravity/types"
 	palomatypes "github.com/palomachain/paloma/x/paloma/types"
 	valsettypes "github.com/palomachain/paloma/x/valset/types"
 	"github.com/palomachain/pigeon/chain"
@@ -176,6 +177,12 @@ func palomaLensClientConfig(palomaConfig config.Paloma) *lens.ChainClientConfig 
 					&consensustypes.MsgSetPublicAccessData{},
 					&consensustypes.MsgSetErrorData{},
 					&palomatypes.MsgAddStatusUpdate{},
+					&gravitytypes.MsgSendToEth{},
+					&gravitytypes.MsgConfirmBatch{},
+					&gravitytypes.MsgSendToPalomaClaim{},
+					&gravitytypes.MsgBatchSendToEthClaim{},
+					&gravitytypes.MsgCancelSendToEth{},
+					&gravitytypes.MsgSubmitBadSignatureEvidence{},
 				},
 			},
 			{
@@ -194,7 +201,7 @@ func palomaLensClientConfig(palomaConfig config.Paloma) *lens.ChainClientConfig 
 			{
 				Iface: (*consensustypes.ConsensusMsg)(nil),
 				Msgs: []proto.Message{
-					&evmtypes.SubmitLogicCall{}, // TODO : Test to ensure this is right
+					&evmtypes.SubmitLogicCall{},
 					&evmtypes.Message{},
 					&evmtypes.ValidatorBalancesAttestation{},
 					&evmtypes.ValidatorBalancesAttestationRes{},


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/939
- https://github.com/VolumeFi/paloma/issues/895

# Background

We have a gravity batch stuck that is being relayed over and over again every 10000 blocks. Pigeon actually see the event on the target chain, but fail to inform Paloma because the gravity messages hadn't been registered against the `sdk.Msg` interface. 

This was most likely just forgotten in the bulk of work for gravity. What bothers me is that this happened before with the `AddStatusUpdate` message, and apparently for some nodes this works just fine, while for others it doesn't and leads to a crash. Definitely needs more understanding. Either the type is registered or it isn't, and if it isn't, it should fail deterministically across all nodes. But it doesn't.

Tested in private test net, this resolves the issue and Pigeon successfully reports the batch as relayed. With this change, we can create a new Pigeon release. Once the majority of validators upgrade, the batch should be removed successfully.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
