### PR TITLE
hack: erc20 relink: store original contract upload tx

### DIFF
--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -781,6 +781,7 @@ func (t compass) provideTxProof(ctx context.Context, queueTypeName string, rawMs
 		"msg-id":             rawMsg.ID,
 		"public-access-data": rawMsg.PublicAccessData,
 	}).Debug("providing proof")
+	lastTxHashLkup[t.ChainReferenceID] = rawMsg.PublicAccessData
 	txHash := common.BytesToHash(rawMsg.PublicAccessData)
 	tx, _, err := t.evm.TransactionByHash(ctx, txHash)
 	if err != nil {


### PR DESCRIPTION
# Background

Before we get around to supporting https://github.com/VolumeFi/paloma/issues/875, we simply kept track of the transaction hash of the original contract upload. However, only the original relaying validator actually kept a reference to this transaction.

So, unless you got selected to relay both the original smart contract as well as the follow-up call to relink the token ownership, you wouldn't have a copy of that hash, meaning you wouldn't be able to attest to the original message.

This change simply creates a reference to the last TX that was attested on each target chain. Since we only verify that the TX in question is present on the target chain, and the ERC20 token relink does not happen after a successful contract deployment, this should be all that's needed to allow Pigeons to attest to this message.

