### PR TITLE
chore: prepare v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This repo does not accept issues. Please use https://github.com/palomachain/palo
 ### To get the latest prebuilt `pigeon` binary:
 
 ```shell
-wget -O - https://github.com/palomachain/pigeon/releases/download/v1.9.5/pigeon_Linux_x86_64.tar.gz  | \
+wget -O - https://github.com/palomachain/pigeon/releases/download/v1.10.0/pigeon_Linux_x86_64.tar.gz  | \
   sudo tar -C /usr/local/bin -xvzf - pigeon
 sudo chmod +x /usr/local/bin/pigeon
 
@@ -69,7 +69,7 @@ mkdir ~/.pigeon
 ```shell
 git clone https://github.com/palomachain/pigeon.git
 cd pigeon
-git checkout v1.9.5
+git checkout v1.10.0
 make build
 sudo mv ./build/pigeon /usr/local/bin/pigeon
 

--- a/go.mod
+++ b/go.mod
@@ -195,6 +195,5 @@ require (
 replace (
 	// Link to op-geth, which is built on top of go-ethereum
 	github.com/ethereum/go-ethereum v1.11.6 => github.com/ethereum-optimism/op-geth v1.101106.0-rc.2
-	github.com/palomachain/paloma => github.com/palomachain/paloma v1.3.1-next.0.20231109175901-fcba98757725
 	github.com/roodeag/arbitrum => github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936
 )

--- a/go.sum
+++ b/go.sum
@@ -850,8 +850,8 @@ github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936 h1:fmQAgxcdYBxCZYczws/uxTVOYHZd4fNrOaoHp35HZMM=
 github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936/go.mod h1:B2H2+2I4UiMR4hvAIaGLyYszNfSTYC8fWIw+kgfuFSQ=
-github.com/palomachain/paloma v1.3.1-next.0.20231109175901-fcba98757725 h1:b/H0twFJ0TPfwEgTO74CLeYwj1DSzInLpgI/Hmud9AE=
-github.com/palomachain/paloma v1.3.1-next.0.20231109175901-fcba98757725/go.mod h1:Jxa/tAPOtQ3lJS4jEa+IMOsFADpHfdkYPS1LEOiEGkQ=
+github.com/palomachain/paloma v1.10.0 h1:OABklLNI982VaO7TF0bdzGSkJ8q+MeUTEi6kQn0Ow9g=
+github.com/palomachain/paloma v1.10.0/go.mod h1:Jxa/tAPOtQ3lJS4jEa+IMOsFADpHfdkYPS1LEOiEGkQ=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
Update README and link to released version of Paloma.