### PR TITLE
fix: avoid overly eager balance lookup

### DIFF
--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -670,8 +670,9 @@ func (c *Client) FindBlockNearestToTime(ctx context.Context, startingHeight uint
 	}
 
 	if res == currBlockHeight {
-		// there needs to be at least one block standing in between
-		return 0, ErrBlockNotYetGenerated
+		// in case the block has just been gerated, return the
+		// previous block number.
+		return res - 1, nil
 	}
 
 	return res, nil

--- a/chain/evm/client_test.go
+++ b/chain/evm/client_test.go
@@ -340,19 +340,6 @@ func TestFindingTheBlockNearestToTime(t *testing.T) {
 		expHeight uint64
 	}{
 		{
-			name:               "one block fails because the same block is the current one",
-			start:              1,
-			when:               time.Unix(100, 0),
-			currentBlockNumber: 1,
-			headers: []ethHeader{
-				{
-					height: 1,
-					time:   1,
-				},
-			},
-			expErr: ErrBlockNotYetGenerated,
-		},
-		{
 			name:               "one block but the time is in the future",
 			start:              1,
 			when:               time.Unix(100, 0),
@@ -407,8 +394,8 @@ func TestFindingTheBlockNearestToTime(t *testing.T) {
 					time:   400,
 				},
 			},
-			expErr:    ErrBlockNotYetGenerated,
-			expHeight: 0,
+			expErr:    nil,
+			expHeight: 2,
 		},
 		{
 			name:               "block has been generated (even number of blocks)",

--- a/chain/evm/errors.go
+++ b/chain/evm/errors.go
@@ -19,10 +19,7 @@ const (
 	ErrCouldntFindBlockWithTime = whoops.String("couldn't find block")
 )
 
-var (
-	ErrStartingBlockIsInTheFuture = ErrCouldntFindBlockWithTime.WrapS("starting height's block time is set in future")
-	ErrBlockNotYetGenerated       = ErrCouldntFindBlockWithTime.WrapS("block has not yet been generated")
-)
+var ErrStartingBlockIsInTheFuture = ErrCouldntFindBlockWithTime.WrapS("starting height's block time is set in future")
 
 const (
 	FieldMessageID   whoops.Field[uint64] = "message id"


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/988

# Background

We see a lot of error logs when trying to verify validators balances on chains. This is because the established architecture allows to query at arbitrary times, even though Paloma always only uses the current time. The algorithm used to identify the closest block to the given time can lead to resulting in the latest block number, which might not be finalised yet. 

For now, we just fall back to the `latest block number - 1` in this case, which should work. In the future, we might want to strip out the entire block height search and always use the current block height, as it's using binary search to approximate the block and makes a decent amount of API calls while doing so.

# Testing completed

- [x] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
