### PR TITLE
Feature/attestation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This repo does not accept issues. Please use https://github.com/palomachain/palo
 ### To get the latest prebuilt `pigeon` binary:
 
 ```shell
-wget -O - https://github.com/palomachain/pigeon/releases/download/v1.10.2/pigeon_Linux_x86_64.tar.gz  | \
+wget -O - https://github.com/palomachain/pigeon/releases/download/v1.10.3/pigeon_Linux_x86_64.tar.gz  | \
   sudo tar -C /usr/local/bin -xvzf - pigeon
 sudo chmod +x /usr/local/bin/pigeon
 
@@ -69,7 +69,7 @@ mkdir ~/.pigeon
 ```shell
 git clone https://github.com/palomachain/pigeon.git
 cd pigeon
-git checkout v1.10.2
+git checkout v1.10.3
 make build
 sudo mv ./build/pigeon /usr/local/bin/pigeon
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ evm:
     gas-adjustment: 1
     tx-type: 2
 
-  arb-main:
+  arbitrum-main:
     chain-id: 42161
     base-rpc-url: ${ARB_RPC_URL}
     keyring-pass-env-name: ARB_PASSWORD

--- a/relayer/message_attester.go
+++ b/relayer/message_attester.go
@@ -67,6 +67,9 @@ func (r *Relayer) attestMessages(ctx context.Context, processors []chain.Process
 				err := p.ProvideEvidence(ctx, queue.FromString(queueName), messagesInQueue)
 				if err != nil {
 					logger.WithError(err).Error("error attesting messages")
+					if err := r.palomaClient.NewStatus().WithArg("error", err.Error()).WithLog("error attesting messages").Error(ctx); err != nil {
+						logger.WithError(err).Error("failed to send Paloma status update")
+					}
 					return err
 				}
 			}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1352

# Background

Change to add a log transaction to Paloma in case of attestation failure. Also increases latest version in README before release.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
