### PR TITLE
fix: invalid gas arg combination

### DIFF
--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -351,6 +351,7 @@ func callSmartContract(
 		if args.txType == 2 {
 			txOpts.GasFeeCap = gasPrice
 			txOpts.GasTipCap = gasTipCap
+			txOpts.GasPrice = nil
 			logger.WithFields(log.Fields{
 				"gas-limit":     txOpts.GasLimit,
 				"gas-max-price": txOpts.GasFeeCap,
@@ -360,6 +361,8 @@ func callSmartContract(
 			}).Debug("executing eip-1559 tx")
 		} else {
 			txOpts.GasPrice = gasPrice
+			txOpts.GasFeeCap = nil
+			txOpts.GasTipCap = nil
 			logger.WithFields(log.Fields{
 				"gas-limit": txOpts.GasLimit,
 				"gas-price": txOpts.GasPrice,


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1488

# Background

This error is ejected directly from the `geth` package before the transaction is even sent to the RPC. I'm not entirely sure why we're seeing this error on main net, as parameters should always be populated as necessary by default. This change adds some explicit statements to `nil` out any fields which may not coexist as part of the transaction options.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
