### PR TITLE
fix: gas estimation error

### DIFF
--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -340,11 +340,15 @@ func callSmartContract(
 			// https://github.com/VolumeFi/paloma/issues/1048
 			value := new(big.Int)
 			gasFeeCap := new(big.Int)
+			var gasLimit uint64
 			if args.txType == 2 {
 				gasFeeCap = gasPrice
+				gasLimit, err = estimateGasLimit(ctx, args.ethClient, txOpts, &args.contract, packedBytes, nil, gasTipCap, gasFeeCap, value)
+				whoops.Assert(err)
+			} else {
+				gasLimit, err = estimateGasLimit(ctx, args.ethClient, txOpts, &args.contract, packedBytes, gasPrice, nil, nil, value)
+				whoops.Assert(err)
 			}
-			gasLimit, err := estimateGasLimit(ctx, args.ethClient, txOpts, &args.contract, packedBytes, gasPrice, gasTipCap, gasFeeCap, value)
-			whoops.Assert(err)
 			txOpts.GasLimit = uint64(float64(gasLimit) * 1.2)
 		}
 

--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -223,7 +223,7 @@ func (t compass) submitLogicCall(
 	logger.WithField("consensus", con).WithField("args", args).Debug("submitting logic call")
 	tx, err := t.callCompass(ctx, msg.ExecutionRequirements.EnforceMEVRelay, "submit_logic_call", args)
 	if err != nil {
-		logger.WithError(err).Error("uploadSmartContract: error calling DeployContract")
+		logger.WithError(err).Error("submitLogicCall: error calling DeployContract")
 		isSmartContractError, setErr := t.SetErrorData(ctx, queueTypeName, origMessage.ID, err)
 		if setErr != nil {
 			return nil, setErr

--- a/go.mod
+++ b/go.mod
@@ -230,6 +230,6 @@ require (
 
 replace (
 	// Link to op-geth, which is built on top of go-ethereum
-	github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101308.4-rc.1
+	github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101311.0
 	github.com/roodeag/arbitrum => github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936
 )

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.0.4 h1:gVPz/FMfvh57HdSJQyvBtF00j8JU4zdyUgIUNhlgg0A=
 github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
-github.com/ethereum-optimism/op-geth v1.101308.4-rc.1 h1:sicj4EhLW8gJffoIRrtLl7Zgv+be8i/L1AZ0xxgInJY=
-github.com/ethereum-optimism/op-geth v1.101308.4-rc.1/go.mod h1:eFb6HyjixYhM8b0r0imIYKKfhPKx+xIvTqbkIipoBig=
+github.com/ethereum-optimism/op-geth v1.101311.0 h1:n0e5WD9kEwuXb5prAO7b+2ctz/sLy6tlJ2qmbbPEi9Y=
+github.com/ethereum-optimism/op-geth v1.101311.0/go.mod h1:K23yb9efVf9DdUOv/vl/Ux57Tng00rLaFqWYlFF45CA=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240318114348-52d3dbd1605d h1:K7HdD/ZAcSFhcqqnUAbvU+8vsg0DzL8pvetHw5vRLCc=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240318114348-52d3dbd1605d/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1501

# Background

The error `both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified` actually happens during gas estimation, and is **not** emitted from the `op-geth` framework. Because it's possible to encounter the **exact same error** in the framework as well, we got led astray.

This change fixes the gas estimation in a way that should force all `tx type 2` chains to omit the gas price entirely when making the call. 

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
