### PR TITLE
fix: gravity gRPC client implementation

### DIFF
--- a/chain/paloma/gravity.go
+++ b/chain/paloma/gravity.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/grpc"
 	gravity "github.com/palomachain/paloma/x/gravity/types"
+	"github.com/palomachain/paloma/x/valset/types"
 	"github.com/palomachain/pigeon/chain"
 )
 
@@ -38,6 +39,9 @@ func gravityConfirmBatch(
 			EthSigner:     signedBatch.SignedByAddress,
 			Orchestrator:  creator,
 			Signature:     hex.EncodeToString(signedBatch.Signature),
+			Metadata: types.MsgMetadata{
+				Creator: creator,
+			},
 		}
 		_, err := ms.SendMsg(ctx, msg, "")
 		return err

--- a/chain/paloma/gravity.go
+++ b/chain/paloma/gravity.go
@@ -4,56 +4,15 @@ import (
 	"context"
 	"encoding/hex"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/gogoproto/grpc"
 	gravity "github.com/palomachain/paloma/x/gravity/types"
-	"github.com/palomachain/paloma/x/valset/types"
 	"github.com/palomachain/pigeon/chain"
 )
 
 func (c *Client) GravityQueryLastUnsignedBatch(ctx context.Context, chainReferenceID string) ([]gravity.OutgoingTxBatch, error) {
-	return gravityQueryLastUnsignedBatch(ctx, c.GRPCClient, c.creator, chainReferenceID)
-}
-
-func (c *Client) GravityConfirmBatches(ctx context.Context, signatures ...chain.SignedGravityOutgoingTxBatch) error {
-	return gravityConfirmBatch(ctx, c.MessageSender, c.creator, signatures...)
-}
-
-func (c *Client) GravityQueryBatchesForRelaying(ctx context.Context, chainReferenceID string) ([]chain.GravityBatchWithSignatures, error) {
-	return gravityQueryBatchesForRelaying(ctx, c.GRPCClient, c.valAddr, chainReferenceID)
-}
-
-func gravityConfirmBatch(
-	ctx context.Context,
-	ms MessageSender,
-	creator string,
-	signedBatches ...chain.SignedGravityOutgoingTxBatch,
-) error {
-	if len(signedBatches) == 0 {
-		return nil
-	}
-	for _, signedBatch := range signedBatches {
-		msg := &gravity.MsgConfirmBatch{
-			Nonce:         signedBatch.BatchNonce,
-			TokenContract: signedBatch.TokenContract,
-			EthSigner:     signedBatch.SignedByAddress,
-			Orchestrator:  creator,
-			Signature:     hex.EncodeToString(signedBatch.Signature),
-			Metadata: types.MsgMetadata{
-				Creator: creator,
-			},
-		}
-		_, err := ms.SendMsg(ctx, msg, "")
-		return err
-
-	}
-	return nil
-}
-
-func gravityQueryLastUnsignedBatch(ctx context.Context, grpcClient grpc.ClientConn, address string, chainReferenceID string) ([]gravity.OutgoingTxBatch, error) {
-	qc := gravity.NewQueryClient(grpcClient)
+	// return gravityQueryLastUnsignedBatch(ctx, c.GRPCClient, c.creator, chainReferenceID)
+	qc := gravity.NewQueryClient(c.GRPCClient)
 	batches, err := qc.LastPendingBatchRequestByAddr(ctx, &gravity.QueryLastPendingBatchRequestByAddrRequest{
-		Address: address,
+		Address: c.creator,
 	})
 	if err != nil {
 		return nil, err
@@ -69,13 +28,33 @@ func gravityQueryLastUnsignedBatch(ctx context.Context, grpcClient grpc.ClientCo
 	return filtered, nil
 }
 
-func gravityQueryBatchesForRelaying(ctx context.Context, grpcClient grpc.ClientConn, address sdk.ValAddress, chainReferenceID string) ([]chain.GravityBatchWithSignatures, error) {
-	qc := gravity.NewQueryClient(grpcClient)
+func (c *Client) GravityConfirmBatches(ctx context.Context, signatures ...chain.SignedGravityOutgoingTxBatch) error {
+	if len(signatures) == 0 {
+		return nil
+	}
+	for _, signedBatch := range signatures {
+		msg := &gravity.MsgConfirmBatch{
+			Nonce:         signedBatch.BatchNonce,
+			TokenContract: signedBatch.TokenContract,
+			EthSigner:     signedBatch.SignedByAddress,
+			Orchestrator:  c.creator,
+			Signature:     hex.EncodeToString(signedBatch.Signature),
+		}
+		_, err := c.MessageSender.SendMsg(ctx, msg, "", c.sendingOpts...)
+		return err
+
+	}
+	return nil
+}
+
+func (c *Client) GravityQueryBatchesForRelaying(ctx context.Context, chainReferenceID string) ([]chain.GravityBatchWithSignatures, error) {
+	// return gravityQueryBatchesForRelaying(ctx, c.GRPCClient, c.valAddr, chainReferenceID)
+	qc := gravity.NewQueryClient(c.GRPCClient)
 
 	// Get batches
 	req := &gravity.QueryOutgoingTxBatchesRequest{
 		ChainReferenceId: chainReferenceID,
-		Assignee:         address.String(),
+		Assignee:         c.valAddr.String(),
 	}
 	batches, err := qc.OutgoingTxBatches(ctx, req)
 	if err != nil {

--- a/chain/paloma/wrappers.go
+++ b/chain/paloma/wrappers.go
@@ -92,6 +92,8 @@ func (m *PalomaMessageSender) SendMsg(ctx context.Context, msg sdk.Msg, memo str
 		return nil, fmt.Errorf("failed to inject metadata: %w", err)
 	}
 
+	liblog.WithContext(ctx).WithField("msg", msg).Info("sending-msg")
+
 	res, err := m.W.SendMsg(ctx, msg, memo, opts...)
 	if IsPalomaDown(err) {
 		return nil, whoops.Wrap(ErrPalomaIsDown, err)

--- a/chain/paloma/wrappers.go
+++ b/chain/paloma/wrappers.go
@@ -84,7 +84,6 @@ func (m *PalomaMessageSender) SendMsg(ctx context.Context, msg sdk.Msg, memo str
 	signer := m.GetSigner()
 
 	logger.WithField("creator", creator).WithField("signer", signer).Debug("Injecting metadata")
-
 	if err := tryInjectMetadata(msg, vtypes.MsgMetadata{
 		Creator: m.GetCreator(),
 		Signers: []string{signer},
@@ -92,8 +91,7 @@ func (m *PalomaMessageSender) SendMsg(ctx context.Context, msg sdk.Msg, memo str
 		return nil, fmt.Errorf("failed to inject metadata: %w", err)
 	}
 
-	liblog.WithContext(ctx).WithField("msg", msg).Info("sending-msg")
-
+	logger.WithField("msg", msg).Debug("Sending message...")
 	res, err := m.W.SendMsg(ctx, msg, memo, opts...)
 	if IsPalomaDown(err) {
 		return nil, whoops.Wrap(ErrPalomaIsDown, err)

--- a/util/ion/broadcast.go
+++ b/util/ion/broadcast.go
@@ -11,6 +11,7 @@ import (
 	tmtypes "github.com/cometbft/cometbft/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/palomachain/pigeon/internal/liblog"
 )
 
 const (
@@ -67,6 +68,7 @@ func broadcastTx(
 	// in the mempool or we can retry the broadcast at that
 	// point
 	syncRes, err := broadcaster.BroadcastTxSync(ctx, tx)
+	liblog.WithContext(ctx).WithError(err).WithField("result", syncRes).Warn("broastcastTX")
 	if err != nil {
 		if syncRes == nil {
 			// There are some cases where BroadcastTxSync will return an error but the associated

--- a/util/ion/broadcast.go
+++ b/util/ion/broadcast.go
@@ -68,8 +68,8 @@ func broadcastTx(
 	// in the mempool or we can retry the broadcast at that
 	// point
 	syncRes, err := broadcaster.BroadcastTxSync(ctx, tx)
-	liblog.WithContext(ctx).WithError(err).WithField("result", syncRes).Warn("broastcastTX")
 	if err != nil {
+		liblog.WithContext(ctx).WithError(err).Warn("Failed to broadcast TX.")
 		if syncRes == nil {
 			// There are some cases where BroadcastTxSync will return an error but the associated
 			// ResultBroadcastTx will be nil.
@@ -86,6 +86,7 @@ func broadcastTx(
 	// This catches all of the sdk errors https://github.com/cosmos/cosmos-sdk/blob/f10f5e5974d2ecbf9efc05bc0bfe1c99fdeed4b6/types/errors/errors.go
 	err = errors.Unwrap(sdkerrors.ABCIError(syncRes.Codespace, syncRes.Code, "error broadcasting transaction"))
 	if err.Error() != errUnknown {
+		liblog.WithContext(ctx).WithError(err).WithField("sync-result", syncRes).Warn("Failed to broadcast TX.")
 		return nil, err
 	}
 	if syncRes.Code != 0 {

--- a/util/ion/tx.go
+++ b/util/ion/tx.go
@@ -116,8 +116,6 @@ func (cc *Client) SendMsgs(ctx context.Context, msgs []sdk.Msg, memo string, opt
 		return nil, err
 	}
 
-	liblog.WithContext(ctx).WithField("component", "send-msgs").WithField("txf", txf).WithField("calculated-gas", adjusted).Info("Finished building txf")
-
 	// Generate the transaction bytes
 	txBytes, err := cc.Codec.TxConfig.TxEncoder()(txb.GetTx())
 	if err != nil {
@@ -127,7 +125,6 @@ func (cc *Client) SendMsgs(ctx context.Context, msgs []sdk.Msg, memo string, opt
 	// Broadcast those bytes
 	res, err := cc.BroadcastTx(ctx, txBytes)
 	if err != nil {
-		liblog.WithContext(ctx).WithField("component", "send-msgs").WithField("txf", txf).WithField("calculated-gas", adjusted).WithError(err).Warn("failed")
 		return nil, fmt.Errorf("failed to broadcast tx: %w", err)
 	}
 

--- a/util/ion/tx.go
+++ b/util/ion/tx.go
@@ -116,6 +116,8 @@ func (cc *Client) SendMsgs(ctx context.Context, msgs []sdk.Msg, memo string, opt
 		return nil, err
 	}
 
+	liblog.WithContext(ctx).WithField("component", "send-msgs").WithField("txf", txf).WithField("calculated-gas", adjusted).Info("Finished building txf")
+
 	// Generate the transaction bytes
 	txBytes, err := cc.Codec.TxConfig.TxEncoder()(txb.GetTx())
 	if err != nil {
@@ -125,6 +127,7 @@ func (cc *Client) SendMsgs(ctx context.Context, msgs []sdk.Msg, memo string, opt
 	// Broadcast those bytes
 	res, err := cc.BroadcastTx(ctx, txBytes)
 	if err != nil {
+		liblog.WithContext(ctx).WithField("component", "send-msgs").WithField("txf", txf).WithField("calculated-gas", adjusted).WithError(err).Warn("failed")
 		return nil, fmt.Errorf("failed to broadcast tx: %w", err)
 	}
 

--- a/util/ion/tx.go
+++ b/util/ion/tx.go
@@ -107,7 +107,7 @@ func (cc *Client) SendMsgs(ctx context.Context, msgs []sdk.Msg, memo string, opt
 		defer done()
 		liblog.WithContext(ctx).WithField("component", "send-msgs").WithField("key", cc.Config.Key).Info("signing transaction")
 		if err = tx.Sign(ctx, txf, cc.Config.Key, txb, false); err != nil {
-			return err
+			return fmt.Errorf("failed to sign tx: %w", err)
 		}
 		return nil
 	}()
@@ -119,13 +119,13 @@ func (cc *Client) SendMsgs(ctx context.Context, msgs []sdk.Msg, memo string, opt
 	// Generate the transaction bytes
 	txBytes, err := cc.Codec.TxConfig.TxEncoder()(txb.GetTx())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to encode tx: %w", err)
 	}
 
 	// Broadcast those bytes
 	res, err := cc.BroadcastTx(ctx, txBytes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to broadcast tx: %w", err)
 	}
 
 	// transaction was executed, log the success or failure using the tx response code


### PR DESCRIPTION
# Background

The gRPC message sender implementation for gravity was never properly updated to work with multiple signing keys in Pigeon. This change adds the necessary changes to ensure all messages are sent with fee grant in mind.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
