### PR TITLE
chore: increase gas limit multiplier to 1.5f

### DIFF
--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -349,7 +349,7 @@ func callSmartContract(
 				gasLimit, err = estimateGasLimit(ctx, args.ethClient, txOpts, &args.contract, packedBytes, gasPrice, nil, nil, value)
 				whoops.Assert(err)
 			}
-			txOpts.GasLimit = uint64(float64(gasLimit) * 1.2)
+			txOpts.GasLimit = uint64(float64(gasLimit) * 1.5)
 		}
 
 		if args.txType == 2 {

--- a/chain/evm/client_test.go
+++ b/chain/evm/client_test.go
@@ -135,7 +135,7 @@ func TestExecutingSmartContract(t *testing.T) {
 				ethMock.On("EstimateGas", mock.Anything, mock.Anything).Return(uint64(222), nil)
 
 				mevMock := newMockMevClient(t)
-				mevMock.On("Relay", mock.Anything, mock.Anything, mock.Anything).Return(common.HexToHash("0xde13fda4e25fc73f1d7f3b3e7652a56a0d0a8a6a361dcaec4c8c77f3720a05d1"), nil)
+				mevMock.On("Relay", mock.Anything, mock.Anything, mock.Anything).Return(common.HexToHash("0x2383690e509c7a7210257a9c713baf03561ee562bdc35f5acba138e5c15acb6c"), nil)
 
 				args.ethClient = ethMock
 				args.mevClient = mevMock


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1639#event-13005610845

# Background

> We found some transactions can fail if we don't provide gas enough.
> https://github.com/VolumeFi/pigeon/blob/e67c743dc9bace0b755d8460750c4e608d80d5c5/chain/evm/client.go#L352
> I suggest multiplication by >=1.3 instead 1.2.
> 1.5 will be good enough.


# Testing completed

- [x] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
