### PR TITLE
fix: failed to marshal JSON for types.Any

### DIFF
--- a/chain/paloma/wrappers.go
+++ b/chain/paloma/wrappers.go
@@ -91,7 +91,7 @@ func (m *PalomaMessageSender) SendMsg(ctx context.Context, msg sdk.Msg, memo str
 		return nil, fmt.Errorf("failed to inject metadata: %w", err)
 	}
 
-	logger.WithField("msg", msg).Debug("Sending message...")
+	logger.WithField("msg", msg.String()).Debug("Sending message...")
 	res, err := m.W.SendMsg(ctx, msg, memo, opts...)
 	if IsPalomaDown(err) {
 		return nil, whoops.Wrap(ErrPalomaIsDown, err)


### PR DESCRIPTION
# Related Github tickets

- Closes https://github.com/VolumeFi/paloma/issues/1705

# Background

The logger was trying to marshal `MsgAddEvidence` messages as JSON, but failing on the `Any` fields, as it does not have access to the unpacker interfaces registry.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [ ] I have checked my code for breaking changes
