### PR TITLE
feat: add compass ID to all turnstone messages

### DIFF
--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -956,6 +956,7 @@ func (t compass) submitBatchSendToEVMClaim(ctx context.Context, event chain.Batc
 		ChainReferenceId: t.ChainReferenceID,
 		Orchestrator:     orchestrator,
 		SkywayNonce:      event.SkywayNonce,
+		CompassId:        t.CompassID,
 	}
 	return t.paloma.SendBatchSendToEVMClaim(ctx, msg)
 }
@@ -971,6 +972,7 @@ func (t compass) submitSendToPalomaClaim(ctx context.Context, event chain.SendTo
 		ChainReferenceId: t.ChainReferenceID,
 		Orchestrator:     orchestrator,
 		SkywayNonce:      event.SkywayNonce,
+		CompassId:        t.CompassID,
 	}
 	return t.paloma.SendSendToPalomaClaim(ctx, msg)
 }
@@ -985,6 +987,7 @@ func (t compass) submitLightNodeSaleClaim(ctx context.Context, event chain.Light
 		Orchestrator:         orchestrator,
 		SkywayNonce:          event.SkywayNonce,
 		SmartContractAddress: event.SmartContractAddress,
+		CompassId:            t.CompassID,
 	}
 	return t.paloma.SendLightNodeSaleClaim(ctx, msg)
 }

--- a/go.mod
+++ b/go.mod
@@ -232,3 +232,5 @@ replace (
 
 	github.com/roodeag/arbitrum => github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936
 )
+
+replace github.com/palomachain/paloma => github.com/palomachain/paloma v1.3.1-next.0.20240809084129-00b863098ab7

--- a/go.sum
+++ b/go.sum
@@ -949,8 +949,8 @@ github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnh
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936 h1:fmQAgxcdYBxCZYczws/uxTVOYHZd4fNrOaoHp35HZMM=
 github.com/palomachain/arb-geth v0.0.0-20230824112942-8e77a580a936/go.mod h1:B2H2+2I4UiMR4hvAIaGLyYszNfSTYC8fWIw+kgfuFSQ=
-github.com/palomachain/paloma v1.15.6 h1:V9Mx460obbaOfwgf13KpUaZp9DHZRKMwHdZM5etGktw=
-github.com/palomachain/paloma v1.15.6/go.mod h1:91O0VRxBof+IXTZxSsSbk/lV2DSaWQIdUaoCBv6HXDo=
+github.com/palomachain/paloma v1.3.1-next.0.20240809084129-00b863098ab7 h1:vW8TOXU16j8BRX8kpBAkVsbHnP0KlnL6Z65InVbfYyw=
+github.com/palomachain/paloma v1.3.1-next.0.20240809084129-00b863098ab7/go.mod h1:91O0VRxBof+IXTZxSsSbk/lV2DSaWQIdUaoCBv6HXDo=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1848

# Background

Skyway needs to know the compass ID that generated the turnstone messages, this PR adds it to all messages.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
