### PR TITLE
fix: allow 20 and 32 bytes addresses from events

### DIFF
--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -1398,8 +1398,20 @@ func compassBytesToPalomaAddress(b any) (sdk.AccAddress, error) {
 		return addr, fmt.Errorf("invalid paloma address bytes")
 	}
 
-	// Keep only the last 20 bytes, removing the first 12 zeroes
-	addrBytes := rawBytes[12:]
+	var addrBytes []byte
+	for i := range rawBytes {
+		if rawBytes[i] != 0 {
+			// Allow addresses starting with 0 and align to either 20 or 32
+			// bytes
+			if i < 12 {
+				addrBytes = rawBytes[:]
+			} else {
+				addrBytes = rawBytes[12:]
+			}
+
+			break
+		}
+	}
 
 	// The Unmarshal function below does not check for errors, so we need to do
 	// it beforehand

--- a/chain/evm/compass_test.go
+++ b/chain/evm/compass_test.go
@@ -2063,3 +2063,49 @@ func TestIfTheConsensusHasBeenReached(t *testing.T) {
 		})
 	}
 }
+
+func TestCompassBytesToPaloma(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		src  [32]byte
+		res  sdk.AccAddress
+		err  bool
+	}{
+		{
+			name: "20 byte address",
+			src:  [32]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			res:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			name: "20 byte address starting with 0",
+			src:  [32]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			res:  []byte{0, 0, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			name: "32 byte address",
+			src:  [32]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			res:  []byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			name: "32 byte address starting with 0",
+			src:  [32]byte{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			res:  []byte{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			name: "invalid address",
+			src:  [32]byte{},
+			err:  true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := compassBytesToPalomaAddress(tt.src)
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.res, res)
+		})
+	}
+}


### PR DESCRIPTION
# Background

Paloma addresses can have 20 or 32 bytes. Address from compass are always 32 bytes left-padded with zeroes. This handles decoding both types of addresses.

# Testing completed

- [x] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
