### PR TITLE
feat: improve gas estimation

### DIFF
--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -351,15 +351,18 @@ func callSmartContract(
 		logger.WithFields(log.Fields{
 			"gas-limit": gasLimit,
 		}).Debug("estimated gas limit")
-		txOpts.GasLimit = uint64(float64(gasLimit) * 1.5)
 
 		// In case we only want to estimate, now is the time to return.
 		if args.opts.estimateOnly {
 			return ethtypes.NewTx(
 				&ethtypes.LegacyTx{
-					Gas: txOpts.GasLimit,
+					Gas: gasLimit,
 				})
 		}
+
+		// Once estimation is finished, we adjust the gas limit
+		// to be sure that the tx will be included in the next block.
+		txOpts.GasLimit = uint64(float64(gasLimit) * 1.5)
 
 		if args.txType == 2 {
 			txOpts.GasFeeCap = gasPrice

--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -115,6 +115,7 @@ type PalomaClienter interface {
 	QueryLastObservedSkywayNonceByAddr(ctx context.Context, chainReferenceID string, orchestrator string) (uint64, error)
 	QueryBatchRequestByNonce(ctx context.Context, nonce uint64, contract string) (skywaytypes.OutgoingTxBatch, error)
 	QueryGetLatestPublishedSnapshot(ctx context.Context, chainReferenceID string) (*valset.Snapshot, error)
+	QueryGetSnapshotByID(ctx context.Context, id uint64) (*valset.Snapshot, error)
 }
 
 type Client struct {

--- a/chain/evm/client_test.go
+++ b/chain/evm/client_test.go
@@ -161,7 +161,7 @@ func TestExecutingSmartContract(t *testing.T) {
 				args.ethClient = ethMock
 				args.opts.estimateOnly = true
 			},
-			expectedEstimated: &([]uint64{333})[0], // afford for 1.5 multiplier
+			expectedEstimated: &([]uint64{222})[0], // will not be with the 1.5 multiplier safety margin
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -1601,12 +1601,12 @@ func (t compass) performValsetIDCrosscheck(ctx context.Context, chainReferenceID
 func (t compass) findAssigneeEthAddress(ctx context.Context,
 	palomaAddress string,
 ) (common.Address, error) {
-	valset, err := t.paloma.QueryGetLatestPublishedSnapshot(ctx, t.ChainReferenceID)
+	snapshot, err := t.paloma.QueryGetSnapshotByID(ctx, 0)
 	if err != nil {
 		return common.Address{}, err
 	}
 
-	for _, v := range valset.Validators {
+	for _, v := range snapshot.Validators {
 		if v.Address.String() == palomaAddress {
 			for _, ci := range v.ExternalChainInfos {
 				if ci.ChainReferenceID == t.ChainReferenceID {

--- a/chain/evm/compass_test.go
+++ b/chain/evm/compass_test.go
@@ -320,23 +320,21 @@ func TestMessageProcessing(t *testing.T) {
 					nil,
 				)
 
-				paloma.On("QueryGetLatestPublishedSnapshot", mock.Anything, "internal-chain-id").Return(
-					&valsettypes.Snapshot{
-						Id: 55,
-						Validators: []valsettypes.Validator{
-							{
-								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
-									{
-										ChainReferenceID: "internal-chain-id",
-										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
-									},
+				sn := &valsettypes.Snapshot{
+					Id: 55,
+					Validators: []valsettypes.Validator{
+						{
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "internal-chain-id",
+									Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
 								},
-								Address: sdk.ValAddress("validator-1").Bytes(),
 							},
+							Address: sdk.ValAddress("validator-1").Bytes(),
 						},
 					},
-					nil,
-				)
+				}
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(sn, nil)
 
 				return evm, paloma
 			},
@@ -405,6 +403,23 @@ func TestMessageProcessing(t *testing.T) {
 					nil,
 				)
 				paloma.On("QueryGetLatestPublishedSnapshot", mock.Anything, "internal-chain-id").Return(
+					&valsettypes.Snapshot{
+						Id: 55,
+						Validators: []valsettypes.Validator{
+							{
+								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+									{
+										ChainReferenceID: "internal-chain-id",
+										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
+									},
+								},
+								Address: sdk.ValAddress("validator-1").Bytes(),
+							},
+						},
+					},
+					nil,
+				)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
 					&valsettypes.Snapshot{
 						Id: 55,
 						Validators: []valsettypes.Validator{
@@ -502,6 +517,23 @@ func TestMessageProcessing(t *testing.T) {
 					},
 					nil,
 				)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
+					&valsettypes.Snapshot{
+						Id: 55,
+						Validators: []valsettypes.Validator{
+							{
+								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+									{
+										ChainReferenceID: "internal-chain-id",
+										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
+									},
+								},
+								Address: sdk.ValAddress("validator-1").Bytes(),
+							},
+						},
+					},
+					nil,
+				)
 
 				evm.On("ExecuteSmartContract", mock.Anything, chainID, mock.Anything, smartContractAddr, callOptions{estimateOnly: true}, "submit_logic_call", mock.Anything).Return(
 					tx,
@@ -569,6 +601,23 @@ func TestMessageProcessing(t *testing.T) {
 					},
 					nil,
 				)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
+					&valsettypes.Snapshot{
+						Id: 56,
+						Validators: []valsettypes.Validator{
+							{
+								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+									{
+										ChainReferenceID: "internal-chain-id",
+										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
+									},
+								},
+								Address: sdk.ValAddress("validator-1").Bytes(),
+							},
+						},
+					},
+					nil,
+				)
 				paloma.On("NewStatus").Return(&StatusUpdater{})
 				return evm, paloma
 			},
@@ -613,6 +662,23 @@ func TestMessageProcessing(t *testing.T) {
 				)
 
 				paloma.On("QueryGetLatestPublishedSnapshot", mock.Anything, "internal-chain-id").Return(
+					&valsettypes.Snapshot{
+						Id: 56,
+						Validators: []valsettypes.Validator{
+							{
+								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+									{
+										ChainReferenceID: "internal-chain-id",
+										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
+									},
+								},
+								Address: sdk.ValAddress("validator-1").Bytes(),
+							},
+						},
+					},
+					nil,
+				)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
 					&valsettypes.Snapshot{
 						Id: 56,
 						Validators: []valsettypes.Validator{
@@ -699,6 +765,23 @@ func TestMessageProcessing(t *testing.T) {
 					nil,
 				)
 				paloma.On("QueryGetLatestPublishedSnapshot", mock.Anything, "internal-chain-id").Return(
+					&valsettypes.Snapshot{
+						Id: 55,
+						Validators: []valsettypes.Validator{
+							{
+								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+									{
+										ChainReferenceID: "internal-chain-id",
+										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
+									},
+								},
+								Address: sdk.ValAddress("validator-1").Bytes(),
+							},
+						},
+					},
+					nil,
+				)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
 					&valsettypes.Snapshot{
 						Id: 55,
 						Validators: []valsettypes.Validator{
@@ -810,6 +893,23 @@ func TestMessageProcessing(t *testing.T) {
 					},
 					nil,
 				)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
+					&valsettypes.Snapshot{
+						Id: 55,
+						Validators: []valsettypes.Validator{
+							{
+								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+									{
+										ChainReferenceID: "internal-chain-id",
+										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
+									},
+								},
+								Address: sdk.ValAddress("validator-1").Bytes(),
+							},
+						},
+					},
+					nil,
+				)
 				evm.On("FindCurrentBlockNumber", mock.Anything).Return(
 					big.NewInt(0),
 					nil,
@@ -873,6 +973,23 @@ func TestMessageProcessing(t *testing.T) {
 					nil,
 				)
 				paloma.On("QueryGetLatestPublishedSnapshot", mock.Anything, "internal-chain-id").Return(
+					&valsettypes.Snapshot{
+						Id: 55,
+						Validators: []valsettypes.Validator{
+							{
+								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+									{
+										ChainReferenceID: "internal-chain-id",
+										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
+									},
+								},
+								Address: sdk.ValAddress("validator-1").Bytes(),
+							},
+						},
+					},
+					nil,
+				)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
 					&valsettypes.Snapshot{
 						Id: 55,
 						Validators: []valsettypes.Validator{
@@ -975,6 +1092,23 @@ func TestMessageProcessing(t *testing.T) {
 					},
 					nil,
 				)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
+					&valsettypes.Snapshot{
+						Id: 55,
+						Validators: []valsettypes.Validator{
+							{
+								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+									{
+										ChainReferenceID: "internal-chain-id",
+										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
+									},
+								},
+								Address: sdk.ValAddress("validator-1").Bytes(),
+							},
+						},
+					},
+					nil,
+				)
 
 				return evm, paloma
 			},
@@ -1027,6 +1161,23 @@ func TestMessageProcessing(t *testing.T) {
 							powerFromPercentage(0.35),
 						},
 						ValsetID: uint64(currentValsetID),
+					},
+					nil,
+				)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
+					&valsettypes.Snapshot{
+						Id: 55,
+						Validators: []valsettypes.Validator{
+							{
+								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+									{
+										ChainReferenceID: "internal-chain-id",
+										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
+									},
+								},
+								Address: sdk.ValAddress("validator-1").Bytes(),
+							},
+						},
 					},
 					nil,
 				)
@@ -1112,7 +1263,7 @@ func TestMessageProcessing(t *testing.T) {
 					},
 					nil,
 				)
-				paloma.On("QueryGetLatestPublishedSnapshot", mock.Anything, "internal-chain-id").Return(
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
 					&valsettypes.Snapshot{
 						Validators: []valsettypes.Validator{
 							{
@@ -1197,7 +1348,7 @@ func TestMessageProcessing(t *testing.T) {
 					},
 					nil,
 				)
-				paloma.On("QueryGetLatestPublishedSnapshot", mock.Anything, "internal-chain-id").Return(
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
 					&valsettypes.Snapshot{
 						Validators: []valsettypes.Validator{
 							{
@@ -1279,7 +1430,7 @@ func TestMessageProcessing(t *testing.T) {
 					},
 					nil,
 				)
-				paloma.On("QueryGetLatestPublishedSnapshot", mock.Anything, "internal-chain-id").Return(
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(
 					&valsettypes.Snapshot{
 						Validators: []valsettypes.Validator{
 							{
@@ -1358,25 +1509,20 @@ func TestMessageProcessing(t *testing.T) {
 							powerFromPercentage(0.4),
 						},
 						ValsetID: uint64(currentValsetID),
-					},
-					nil,
-				)
-				paloma.On("QueryGetLatestPublishedSnapshot", mock.Anything, "internal-chain-id").Return(
-					&valsettypes.Snapshot{
-						Validators: []valsettypes.Validator{
-							{
-								ExternalChainInfos: []*valsettypes.ExternalChainInfo{
-									{
-										ChainReferenceID: "internal-chain-id",
-										Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
-									},
+					}, nil)
+				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(&valsettypes.Snapshot{
+					Validators: []valsettypes.Validator{
+						{
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "internal-chain-id",
+									Address:          "0xDEADBEEF0ba39494ce839613fffba74279579268",
 								},
-								Address: sdk.ValAddress("validator-1").Bytes(),
 							},
+							Address: sdk.ValAddress("validator-1").Bytes(),
 						},
 					},
-					nil,
-				)
+				}, nil)
 				return evm, paloma
 			},
 		},

--- a/chain/evm/mocks/CompassBinding.go
+++ b/chain/evm/mocks/CompassBinding.go
@@ -52,6 +52,36 @@ func (_m *CompassBinding) CompassId(opts *bind.CallOpts) ([32]byte, error) {
 	return r0, r1
 }
 
+// CompassUpdateBatch provides a mock function with given fields: opts, consensus, update_compass_args, deadline, gas_estimate, relayer
+func (_m *CompassBinding) CompassUpdateBatch(opts *bind.TransactOpts, consensus compass.Struct2, update_compass_args []compass.Struct4, deadline *big.Int, gas_estimate *big.Int, relayer common.Address) (*types.Transaction, error) {
+	ret := _m.Called(opts, consensus, update_compass_args, deadline, gas_estimate, relayer)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CompassUpdateBatch")
+	}
+
+	var r0 *types.Transaction
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*bind.TransactOpts, compass.Struct2, []compass.Struct4, *big.Int, *big.Int, common.Address) (*types.Transaction, error)); ok {
+		return rf(opts, consensus, update_compass_args, deadline, gas_estimate, relayer)
+	}
+	if rf, ok := ret.Get(0).(func(*bind.TransactOpts, compass.Struct2, []compass.Struct4, *big.Int, *big.Int, common.Address) *types.Transaction); ok {
+		r0 = rf(opts, consensus, update_compass_args, deadline, gas_estimate, relayer)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.Transaction)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*bind.TransactOpts, compass.Struct2, []compass.Struct4, *big.Int, *big.Int, common.Address) error); ok {
+		r1 = rf(opts, consensus, update_compass_args, deadline, gas_estimate, relayer)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FilterLogicCallEvent provides a mock function with given fields: opts
 func (_m *CompassBinding) FilterLogicCallEvent(opts *bind.FilterOpts) (*compass.CompassLogicCallEventIterator, error) {
 	ret := _m.Called(opts)

--- a/chain/evm/mocks/PalomaClienter.go
+++ b/chain/evm/mocks/PalomaClienter.go
@@ -149,6 +149,36 @@ func (_m *PalomaClienter) QueryGetLatestPublishedSnapshot(ctx context.Context, c
 	return r0, r1
 }
 
+// QueryGetSnapshotByID provides a mock function with given fields: ctx, id
+func (_m *PalomaClienter) QueryGetSnapshotByID(ctx context.Context, id uint64) (*valsettypes.Snapshot, error) {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryGetSnapshotByID")
+	}
+
+	var r0 *valsettypes.Snapshot
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) (*valsettypes.Snapshot, error)); ok {
+		return rf(ctx, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) *valsettypes.Snapshot); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*valsettypes.Snapshot)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // QueryLastObservedSkywayNonceByAddr provides a mock function with given fields: ctx, chainReferenceID, orchestrator
 func (_m *PalomaClienter) QueryLastObservedSkywayNonceByAddr(ctx context.Context, chainReferenceID string, orchestrator string) (uint64, error) {
 	ret := _m.Called(ctx, chainReferenceID, orchestrator)
@@ -272,7 +302,8 @@ func (_m *PalomaClienter) SetPublicAccessData(ctx context.Context, queueTypeName
 func NewPalomaClienter(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *PalomaClienter {
+},
+) *PalomaClienter {
 	mock := &PalomaClienter{}
 	mock.Mock.Test(t)
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2089
- https://github.com/VolumeFi/paloma/issues/2094
- https://github.com/VolumeFi/paloma/issues/2128

# Background

This change addresses the inflated estimate that used to include the `1.5` modifier applied to the limit in order to ensure inclusion in the next tx. Since most of this won't actually be consumed, we now only return the pure, raw estimate retrieved from the RPC.

There's also a bug fix in this, addressing an edge case where the external address resolving of the assignee would fail in case they were jailed during the last published snapshot.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
