### PR TITLE
chore: add receipts to all turnstone tx proofs

### DIFF
--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -1238,23 +1238,16 @@ func (t compass) provideTxProof(ctx context.Context, queueTypeName string, rawMs
 
 	var serializedReceipt []byte
 
-	msg, ok := rawMsg.Msg.(*evmtypes.Message)
-	// If this is a turnstone message, we may need additional info
-	if ok {
-		switch msg.GetAction().(type) {
-		case *evmtypes.Message_UploadUserSmartContract:
-			// For UserUploadSmartContract messages, we need the transaction
-			// receipt, so that paloma can use the generated events to get the
-			// contract address
-			receipt, err := t.evm.TransactionReceipt(ctx, tx.Hash())
-			if err != nil {
-				return err
-			}
+	// If this is a turnstone message, we need to get the tx receipt
+	if _, ok := rawMsg.Msg.(*evmtypes.Message); ok {
+		receipt, err := t.evm.TransactionReceipt(ctx, tx.Hash())
+		if err != nil {
+			return err
+		}
 
-			serializedReceipt, err = receipt.MarshalBinary()
-			if err != nil {
-				return err
-			}
+		serializedReceipt, err = receipt.MarshalBinary()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/chain/evm/compass_test.go
+++ b/chain/evm/compass_test.go
@@ -70,6 +70,10 @@ var (
 		return tx
 	}()
 
+	sampleReceiptTx1 = &ethtypes.Receipt{
+		Status: ethtypes.ReceiptStatusSuccessful,
+	}
+
 	eventIdAtomic = atomic.Int64{}
 )
 
@@ -1915,9 +1919,14 @@ func TestProvidingEvidenceForAMessage(t *testing.T) {
 			setup: func(t *testing.T) (*mockEvmClienter, *evmmocks.PalomaClienter) {
 				evm, paloma := newMockEvmClienter(t), evmmocks.NewPalomaClienter(t)
 				evm.On("TransactionByHash", mock.Anything, mock.Anything).Return(sampleTx1, false, nil)
+				evm.On("TransactionReceipt", mock.Anything, mock.Anything).
+					Return(sampleReceiptTx1, nil)
 
 				paloma.On("AddMessageEvidence", mock.Anything, queue.QueueSuffixTurnstone, uint64(555),
-					&types.TxExecutedProof{SerializedTX: whoops.Must(sampleTx1.MarshalBinary())},
+					&types.TxExecutedProof{
+						SerializedTX:      whoops.Must(sampleTx1.MarshalBinary()),
+						SerializedReceipt: whoops.Must(sampleReceiptTx1.MarshalBinary()),
+					},
 				).Return(
 					nil,
 				)


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2095

# Background

Add transaction receipts to all turnstone message proofs. The receipts will be needed in paloma to attest the txs were successful.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
