### PR TITLE
fix: set ErrorData on all errors from handling a turnstone message

### DIFF
--- a/chain/evm/compass.go
+++ b/chain/evm/compass.go
@@ -819,18 +819,15 @@ func (t compass) processMessages(ctx context.Context, queueTypeName string, msgs
 		default:
 			logger.WithError(processingErr).Error("processing error")
 
-			var setErr error
-
 			if !opts.estimateOnly {
 				// If we're not just estimating, we want to set the error data
 				// on the message
-				setErr = t.SetErrorData(ctx, queueTypeName, rawMsg.ID, processingErr)
-			}
-
-			if setErr != nil {
-				// If we got an error setting the error data, this is the error
-				// we want to log
-				processingErr = setErr
+				setErr := t.SetErrorData(ctx, queueTypeName, rawMsg.ID, processingErr)
+				if setErr != nil {
+					// If we got an error setting the error data, this is the error
+					// we want to log
+					processingErr = setErr
+				}
 			}
 
 			if err := t.paloma.NewStatus().

--- a/chain/evm/compass_test.go
+++ b/chain/evm/compass_test.go
@@ -339,6 +339,7 @@ func TestMessageProcessing(t *testing.T) {
 					},
 				}
 				paloma.On("QueryGetSnapshotByID", mock.Anything, uint64(0)).Return(sn, nil)
+				paloma.On("SetErrorData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 				return evm, paloma
 			},


### PR DESCRIPTION
# Related Github tickets

- Closes https://github.com/VolumeFi/paloma/issues/2191

# Background

Currently some errors do not set ErrorData on turnstone messages. When there's an error on these messages (for instance an RPC error) they just stay on the queue until they expire.

We want all errors to set the ErrorData on messages so they can fail fast and be retried. Furthermore, compass errors are treated as normal errors and returned in the ErrorData as well.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
