### PR TITLE
chore: continue message processing after error

### DIFF
--- a/relayer/errors.go
+++ b/relayer/errors.go
@@ -39,3 +39,11 @@ func handleProcessError(ctx context.Context, err error) error {
 	logger.WithError(err).Error("error returned in process loop")
 	return nil
 }
+
+// isFatal returns true if the error is unrecoverable and the caller should
+// return it immediately
+func isFatal(err error) bool {
+	return goerrors.Is(err, context.Canceled) ||
+		goerrors.Is(err, context.DeadlineExceeded) ||
+		errors.IsUnrecoverable(err)
+}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2201

# Background

Paloma validators are getting jailed too often. One of the causes is if there is an issue on one chain, and pigeons fail to attest message on it, they won't try to attest messages on other chains. This can result in additional jailings after some instability on a chain or RPC provider.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
