### PR TITLE
chore: [#2299] Gas buffer covering compass bootstrap

### DIFF
--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -373,6 +373,11 @@ func callSmartContract(
 			txOpts.GasLimit = args.gasEstimate.Uint64()
 		}
 
+		// Add an additional buffer to cover the cost of gas verification
+		// on Compass.
+		// See https://github.com/VolumeFi/paloma/issues/2299
+		txOpts.GasLimit = txOpts.GasLimit + 100_000
+
 		if args.txType == 2 {
 			txOpts.GasFeeCap = gasPrice
 			txOpts.GasTipCap = gasTipCap

--- a/chain/evm/client_test.go
+++ b/chain/evm/client_test.go
@@ -136,7 +136,7 @@ func TestExecutingSmartContract(t *testing.T) {
 				ethMock.On("EstimateGas", mock.Anything, mock.Anything).Return(uint64(222), nil)
 
 				mevMock := newMockMevClient(t)
-				mevMock.On("Relay", mock.Anything, mock.Anything, mock.Anything).Return(common.HexToHash("0x2383690e509c7a7210257a9c713baf03561ee562bdc35f5acba138e5c15acb6c"), nil)
+				mevMock.On("Relay", mock.Anything, mock.Anything, mock.Anything).Return(common.HexToHash("0xfaa694dd01565c673ecc8aaa70da7abd2e1ea3f7c46a60594bb2768f39603087"), nil)
 
 				args.ethClient = ethMock
 				args.mevClient = mevMock


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2299

# Background

This change adds an additional 100k gas buffer to cover the cost of bootstrapping ops on Compass.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
