### PR TITLE
ci: increase Go version

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Go lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
+          version: v1.63.4
           args: --verbose
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.2'
+          go-version: '1.23.5'
           cache: false
       - name: Go lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   buildx:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # stick with older LTS release for continued debian support
     steps:
       -
         name: Checkout

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,3 +38,4 @@ issues:
     # gosec
     - G101 # Potential hardcoded credentials
     - G114 # Use of net/http serve function that has no support for setting timeouts
+    - G115 # We use this everywhere (I guess at least if it overflows, it will for everyone...)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: '1.22.2'
+  go: '1.23.5'
   issues-exit-code: 1
   timeout: 10m
   modules-download-mode: readonly

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ###########################
 ####     Base image    ####
 ###########################
-FROM golang:1.22-bullseye AS base
+FROM golang:1.23-bullseye AS base
 WORKDIR /app
 
 ###########################

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 BRANCH               := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT               := $(shell git log -1 --format='%H')
 BUILD_DIR            ?= $(CURDIR)/build
-GOLANGCILINT_VERSION := 1.51.2
+GOLANGCILINT_VERSION := 1.63.4
 
 .PHONY: install-linter install-abigen build build-linux
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ mkdir ~/.pigeon
 
 ### To build pigeon using latest
 
+> [!IMPORTANT]  
+> Always make sure you're building against the latest released version of Go.
+
 ```shell
 git clone https://github.com/palomachain/pigeon.git
 cd pigeon

--- a/chain/evm/deploy_contract.go
+++ b/chain/evm/deploy_contract.go
@@ -335,7 +335,6 @@ func (c *Client) wrapArbitrumDeployment(
 		c.config.GasAdjustment,
 		c.config.TxType,
 	)
-
 	if err != nil {
 		logger.WithError(err).Error("failed to deploy contract to arbitrum")
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/palomachain/pigeon
 
-go 1.22.2
+go 1.23.5
 
 require (
 	cosmossdk.io/errors v1.0.1

--- a/internal/mev/blxr/relay.go
+++ b/internal/mev/blxr/relay.go
@@ -73,10 +73,10 @@ func (c *Client) Relay(ctx context.Context, chainID *big.Int, tx *types.Transact
 
 	if res.StatusCode() != http.StatusOK {
 		if len(r.Error.Message) > 0 {
-			return nilHash, fmt.Errorf(r.Error.Message)
+			return nilHash, fmt.Errorf("%s", r.Error.Message)
 		}
 
-		return nilHash, fmt.Errorf(string(res.Body()))
+		return nilHash, fmt.Errorf("%s", string(res.Body()))
 	}
 
 	if len(r.Result.Txhash) < 1 {

--- a/util/ion/tx.go
+++ b/util/ion/tx.go
@@ -111,7 +111,6 @@ func (cc *Client) SendMsgs(ctx context.Context, msgs []sdk.Msg, memo string, opt
 		}
 		return nil
 	}()
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2540

# Background

- Lock the CI runner versions
- Upgrade to the latest released version of Go

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
