### PR TITLE
Revert "feat: experimental support for selective chain relays !breaking"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,10 +4,6 @@ run:
   timeout: 10m
   modules-download-mode: readonly
   allow-parallel-runners: true
-  skip-dirs:
-    - .git
-    - .docker
-    - .bin
 
 linters:
   disable-all: true
@@ -27,6 +23,11 @@ issues:
   # Restricts maximum count of issues to display with the same text, and show all instead.
   max-same-issues: 0
   max-issues-per-linter: 0
+  exclude-dirs-use-default: true
+  exclude-dirs:
+    - .git
+    - .docker
+    - .bin
   exclude-rules:
     # disabling some linters for test files
     - path: _test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,10 @@ run:
   timeout: 10m
   modules-download-mode: readonly
   allow-parallel-runners: true
+  skip-dirs:
+    - .git
+    - .docker
+    - .bin
 
 linters:
   disable-all: true
@@ -23,11 +27,6 @@ issues:
   # Restricts maximum count of issues to display with the same text, and show all instead.
   max-same-issues: 0
   max-issues-per-linter: 0
-  exclude-dirs-use-default: true
-  exclude-dirs:
-    - .git
-    - .docker
-    - .bin
   exclude-rules:
     # disabling some linters for test files
     - path: _test\.go

--- a/relayer/build_processors.go
+++ b/relayer/build_processors.go
@@ -17,6 +17,7 @@ import (
 
 func (r *Relayer) buildProcessors(ctx context.Context, _ sync.Locker) error {
 	logger := liblog.WithContext(ctx)
+	// TODO: This should live in a short lived cache, it's run very often.
 	queriedChainsInfos, err := r.palomaClient.QueryGetEVMChainInfos(ctx)
 	if err != nil {
 		return err
@@ -48,13 +49,13 @@ func (r *Relayer) buildProcessors(ctx context.Context, _ sync.Locker) error {
 		})
 		processor, err := r.processorFactory(chainInfo)
 		if errors.IsUnrecoverable(err) {
-			logger.WithError(err).Error("unable to build processor, skipping...")
-			continue
+			logger.WithError(err).Error("unable to build processor")
+			return err
 		}
 
 		if err := processor.IsRightChain(ctx); err != nil {
-			logger.WithError(err).Error("incorrect chain, skipping...")
-			continue
+			logger.WithError(err).Error("incorrect chain")
+			return err
 		}
 
 		r.processors = append(r.processors, processor)

--- a/relayer/message_attester_test.go
+++ b/relayer/message_attester_test.go
@@ -114,7 +114,7 @@ func TestAttestMessages(t *testing.T) {
 			},
 		},
 		{
-			name: "if the processor is connected to the wrong chain it skips the chain in question",
+			name: "if the processor is connected to the wrong chain it returns the error",
 			setup: func(t *testing.T) *Relayer {
 				keyringPass := "abcd"
 
@@ -161,7 +161,7 @@ func TestAttestMessages(t *testing.T) {
 					Config{},
 				)
 			},
-			expErr: nil,
+			expErr: chain.ErrNotConnectedToRightChain,
 		},
 	}
 

--- a/relayer/message_relayer_test.go
+++ b/relayer/message_relayer_test.go
@@ -117,7 +117,7 @@ func TestRelayMessages(t *testing.T) {
 			},
 		},
 		{
-			name: "if the processor is connected to the wrong chain it skips the chain in question",
+			name: "if the processor is connected to the wrong chain it returns the error",
 			setup: func(t *testing.T) *Relayer {
 				keyringPass := "abcd"
 
@@ -141,7 +141,9 @@ func TestRelayMessages(t *testing.T) {
 						MinOnChainBalance:     "10000",
 					},
 				}, nil)
+
 				factory := mocks.NewEvmFactorier(t)
+
 				factory.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(p, nil)
 
 				return New(
@@ -162,7 +164,7 @@ func TestRelayMessages(t *testing.T) {
 					Config{},
 				)
 			},
-			expErr: nil,
+			expErr: chain.ErrNotConnectedToRightChain,
 		},
 	}
 

--- a/relayer/message_signer_test.go
+++ b/relayer/message_signer_test.go
@@ -108,7 +108,7 @@ func TestSignMessages(t *testing.T) {
 			},
 		},
 		{
-			name: "if the processor is connected to the wrong chain it skips the chain in question",
+			name: "if the processor is connected to the wrong chain it returns the error",
 			setup: func(t *testing.T) *Relayer {
 				keyringPass := "abcd"
 
@@ -155,7 +155,7 @@ func TestSignMessages(t *testing.T) {
 					Config{},
 				)
 			},
-			expErr: nil,
+			expErr: chain.ErrNotConnectedToRightChain,
 		},
 	}
 


### PR DESCRIPTION
Reverts palomachain/pigeon#454

With https://github.com/palomachain/pigeon/pull/455 merged, this is no longer required and should not be rolled out to avoid further instability.